### PR TITLE
check if wporg_get_current_handbook exists

### DIFF
--- a/sidebar-handbook.php
+++ b/sidebar-handbook.php
@@ -5,7 +5,7 @@
  * @package Gutenbergtheme
  */
 
-if ( ! is_active_sidebar( wporg_get_current_handbook() ) )
+if ( ! function_exists( 'wporg_get_current_handbook' ) || ! is_active_sidebar( wporg_get_current_handbook() ) )
 	return;
 ?>
 	<div id="secondary" class="widget-area" role="complementary">


### PR DESCRIPTION
without this, I get fatal error. 

> Fatal error: Uncaught Error: Call to undefined function wporg_get_current_handbook() in `/wp-content/themes/gutenberg-theme/sidebar-handbook.php:8`