### PR TITLE
Grid and flex, first pass

### DIFF
--- a/404.php
+++ b/404.php
@@ -8,53 +8,51 @@
  */
 
 get_header(); ?>
+	
+	<main id="primary" class="site-main">
 
-	<div id="primary" class="content-area">
-		<main id="main" class="site-main">
+		<section class="error-404 not-found">
+			<header class="page-header">
+				<h1 class="page-title"><?php esc_html_e( 'Oops! That page can&rsquo;t be found.', 'gutenbergtheme' ); ?></h1>
+			</header><!-- .page-header -->
 
-			<section class="error-404 not-found">
-				<header class="page-header">
-					<h1 class="page-title"><?php esc_html_e( 'Oops! That page can&rsquo;t be found.', 'gutenbergtheme' ); ?></h1>
-				</header><!-- .page-header -->
+			<div class="page-content">
+				<p><?php esc_html_e( 'It looks like nothing was found at this location. Maybe try one of the links below or a search?', 'gutenbergtheme' ); ?></p>
 
-				<div class="page-content">
-					<p><?php esc_html_e( 'It looks like nothing was found at this location. Maybe try one of the links below or a search?', 'gutenbergtheme' ); ?></p>
+				<?php
+					get_search_form();
 
+					the_widget( 'WP_Widget_Recent_Posts' );
+				?>
+
+				<div class="widget widget_categories">
+					<h2 class="widget-title"><?php esc_html_e( 'Most Used Categories', 'gutenbergtheme' ); ?></h2>
+					<ul>
 					<?php
-						get_search_form();
-
-						the_widget( 'WP_Widget_Recent_Posts' );
+						wp_list_categories( array(
+							'orderby'    => 'count',
+							'order'      => 'DESC',
+							'show_count' => 1,
+							'title_li'   => '',
+							'number'     => 10,
+						) );
 					?>
+					</ul>
+				</div><!-- .widget -->
 
-					<div class="widget widget_categories">
-						<h2 class="widget-title"><?php esc_html_e( 'Most Used Categories', 'gutenbergtheme' ); ?></h2>
-						<ul>
-						<?php
-							wp_list_categories( array(
-								'orderby'    => 'count',
-								'order'      => 'DESC',
-								'show_count' => 1,
-								'title_li'   => '',
-								'number'     => 10,
-							) );
-						?>
-						</ul>
-					</div><!-- .widget -->
+				<?php
 
-					<?php
+					/* translators: %1$s: smiley */
+					$archive_content = '<p>' . sprintf( esc_html__( 'Try looking in the monthly archives. %1$s', 'gutenbergtheme' ), convert_smilies( ':)' ) ) . '</p>';
+					the_widget( 'WP_Widget_Archives', 'dropdown=1', "after_title=</h2>$archive_content" );
 
-						/* translators: %1$s: smiley */
-						$archive_content = '<p>' . sprintf( esc_html__( 'Try looking in the monthly archives. %1$s', 'gutenbergtheme' ), convert_smilies( ':)' ) ) . '</p>';
-						the_widget( 'WP_Widget_Archives', 'dropdown=1', "after_title=</h2>$archive_content" );
+					the_widget( 'WP_Widget_Tag_Cloud' );
+				?>
 
-						the_widget( 'WP_Widget_Tag_Cloud' );
-					?>
+			</div><!-- .page-content -->
+		</section><!-- .error-404 -->
 
-				</div><!-- .page-content -->
-			</section><!-- .error-404 -->
-
-		</main><!-- #main -->
-	</div><!-- #primary -->
+	</main><!-- #primary -->
 
 <?php
 get_footer();

--- a/archive.php
+++ b/archive.php
@@ -9,42 +9,40 @@
 
 get_header(); ?>
 
-	<div id="primary" class="content-area">
-		<main id="main" class="site-main">
+	<main id="primary" class="site-main">
+
+	<?php
+	if ( have_posts() ) : ?>
+
+		<header class="page-header">
+			<?php
+				the_archive_title( '<h1 class="page-title">', '</h1>' );
+				the_archive_description( '<div class="archive-description">', '</div>' );
+			?>
+		</header><!-- .page-header -->
 
 		<?php
-		if ( have_posts() ) : ?>
+		/* Start the Loop */
+		while ( have_posts() ) : the_post();
 
-			<header class="page-header">
-				<?php
-					the_archive_title( '<h1 class="page-title">', '</h1>' );
-					the_archive_description( '<div class="archive-description">', '</div>' );
-				?>
-			</header><!-- .page-header -->
+			/*
+				* Include the Post-Format-specific template for the content.
+				* If you want to override this in a child theme, then include a file
+				* called content-___.php (where ___ is the Post Format name) and that will be used instead.
+				*/
+			get_template_part( 'template-parts/content', get_post_format() );
 
-			<?php
-			/* Start the Loop */
-			while ( have_posts() ) : the_post();
+		endwhile;
 
-				/*
-				 * Include the Post-Format-specific template for the content.
-				 * If you want to override this in a child theme, then include a file
-				 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
-				 */
-				get_template_part( 'template-parts/content', get_post_format() );
+		the_posts_navigation();
 
-			endwhile;
+	else :
 
-			the_posts_navigation();
+		get_template_part( 'template-parts/content', 'none' );
 
-		else :
+	endif; ?>
 
-			get_template_part( 'template-parts/content', 'none' );
-
-		endif; ?>
-
-		</main><!-- #main -->
-	</div><!-- #primary -->
+	</main>><!-- #primary -->
 
 <?php
 get_footer();

--- a/footer.php
+++ b/footer.php
@@ -11,8 +11,6 @@
 
 ?>
 
-</div><!-- #content -->
-
 <footer id="colophon" class="site-footer">
 	<div class="site-info">
 		<a href="<?php echo esc_url( __( 'https://wordpress.org/', '_s' ) ); ?>"><?php

--- a/header.php
+++ b/header.php
@@ -50,4 +50,3 @@
 				?>
 			</nav><!-- #site-navigation -->
 		</header><!-- #masthead -->
-	<div id="content" class="site-content">

--- a/header.php
+++ b/header.php
@@ -21,7 +21,7 @@
 
 <body <?php body_class(); ?>>
 <div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'gutenbergtheme' ); ?></a>
+	<a class="skip-link screen-reader-text" href="#primary"><?php esc_html_e( 'Skip to content', 'gutenbergtheme' ); ?></a>
 		<header id="masthead" class="site-header">
 			<div class="site-branding">
 				<?php

--- a/index.php
+++ b/index.php
@@ -14,42 +14,40 @@
 
 get_header(); ?>
 
-	<div id="primary" class="content-area">
-		<main id="main" class="site-main">
+	<main id="primary" class="site-main">
+
+	<?php
+	if ( have_posts() ) :
+
+		if ( is_home() && ! is_front_page() ) : ?>
+			<header>
+				<h1 class="page-title screen-reader-text"><?php single_post_title(); ?></h1>
+			</header>
 
 		<?php
-		if ( have_posts() ) :
+		endif;
 
-			if ( is_home() && ! is_front_page() ) : ?>
-				<header>
-					<h1 class="page-title screen-reader-text"><?php single_post_title(); ?></h1>
-				</header>
+		/* Start the Loop */
+		while ( have_posts() ) : the_post();
 
-			<?php
-			endif;
+			/*
+				* Include the Post-Format-specific template for the content.
+				* If you want to override this in a child theme, then include a file
+				* called content-___.php (where ___ is the Post Format name) and that will be used instead.
+				*/
+			get_template_part( 'template-parts/content', get_post_format() );
 
-			/* Start the Loop */
-			while ( have_posts() ) : the_post();
+		endwhile;
 
-				/*
-				 * Include the Post-Format-specific template for the content.
-				 * If you want to override this in a child theme, then include a file
-				 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
-				 */
-				get_template_part( 'template-parts/content', get_post_format() );
+		the_posts_navigation();
 
-			endwhile;
+	else :
 
-			the_posts_navigation();
+		get_template_part( 'template-parts/content', 'none' );
 
-		else :
+	endif; ?>
 
-			get_template_part( 'template-parts/content', 'none' );
-
-		endif; ?>
-
-		</main><!-- #main -->
-	</div><!-- #primary -->
+	</main><!-- #primary -->
 
 <?php
 get_footer();

--- a/page.php
+++ b/page.php
@@ -14,24 +14,22 @@
 
 get_header(); ?>
 
-	<div id="primary" class="content-area">
-		<main id="main" class="site-main">
+	<main id="primary" class="site-main">
 
-			<?php
-			while ( have_posts() ) : the_post();
+		<?php
+		while ( have_posts() ) : the_post();
 
-				get_template_part( 'template-parts/content', 'page' );
+			get_template_part( 'template-parts/content', 'page' );
 
-				// If comments are open or we have at least one comment, load up the comment template.
-				if ( comments_open() || get_comments_number() ) :
-					comments_template();
-				endif;
+			// If comments are open or we have at least one comment, load up the comment template.
+			if ( comments_open() || get_comments_number() ) :
+				comments_template();
+			endif;
 
-			endwhile; // End of the loop.
-			?>
+		endwhile; // End of the loop.
+		?>
 
-		</main><!-- #main -->
-	</div><!-- #primary -->
+	</main><!-- #primary -->
 
 <?php
 get_footer();

--- a/search.php
+++ b/search.php
@@ -9,42 +9,40 @@
 
 get_header(); ?>
 
-	<section id="primary" class="content-area">
-		<main id="main" class="site-main">
+	<main id="primary" class="site-main">
+
+	<?php
+	if ( have_posts() ) : ?>
+
+		<header class="page-header">
+			<h1 class="page-title"><?php
+				/* translators: %s: search query. */
+				printf( esc_html__( 'Search Results for: %s', 'gutenbergtheme' ), '<span>' . get_search_query() . '</span>' );
+			?></h1>
+		</header><!-- .page-header -->
 
 		<?php
-		if ( have_posts() ) : ?>
+		/* Start the Loop */
+		while ( have_posts() ) : the_post();
 
-			<header class="page-header">
-				<h1 class="page-title"><?php
-					/* translators: %s: search query. */
-					printf( esc_html__( 'Search Results for: %s', 'gutenbergtheme' ), '<span>' . get_search_query() . '</span>' );
-				?></h1>
-			</header><!-- .page-header -->
+			/**
+			 * Run the loop for the search to output the results.
+			 * If you want to overload this in a child theme then include a file
+			 * called content-search.php and that will be used instead.
+			 */
+			get_template_part( 'template-parts/content', 'search' );
 
-			<?php
-			/* Start the Loop */
-			while ( have_posts() ) : the_post();
+		endwhile;
 
-				/**
-				 * Run the loop for the search to output the results.
-				 * If you want to overload this in a child theme then include a file
-				 * called content-search.php and that will be used instead.
-				 */
-				get_template_part( 'template-parts/content', 'search' );
+		the_posts_navigation();
 
-			endwhile;
+	else :
 
-			the_posts_navigation();
+		get_template_part( 'template-parts/content', 'none' );
 
-		else :
+	endif; ?>
 
-			get_template_part( 'template-parts/content', 'none' );
-
-		endif; ?>
-
-		</main><!-- #main -->
-	</section><!-- #primary -->
+	</main><!-- #primary -->
 
 <?php
 get_footer();

--- a/single.php
+++ b/single.php
@@ -9,29 +9,27 @@
 
 get_header(); ?>
 
-	<div id="primary" class="content-area">
-		<main id="main" class="site-main">
+	<main id="primary" class="site-main">
 
-		<?php
-		while ( have_posts() ) : the_post();
+	<?php
+	while ( have_posts() ) : the_post();
 
-			get_template_part( 'template-parts/content', get_post_type() );
+		get_template_part( 'template-parts/content', get_post_type() );
 
-			the_post_navigation( array(
-				'prev_text' => '← %title',
-				'next_text' => '%title →',
-			) );
+		the_post_navigation( array(
+			'prev_text' => '← %title',
+			'next_text' => '%title →',
+		) );
 
-			// If comments are open or we have at least one comment, load up the comment template.
-			if ( comments_open() || get_comments_number() ) :
-				comments_template();
-			endif;
+		// If comments are open or we have at least one comment, load up the comment template.
+		if ( comments_open() || get_comments_number() ) :
+			comments_template();
+		endif;
 
-		endwhile; // End of the loop.
-		?>
+	endwhile; // End of the loop.
+	?>
 
-		</main><!-- #main -->
-	</div><!-- #primary -->
+	</main><!-- #primary -->
 
 <?php
 get_footer();

--- a/style.css
+++ b/style.css
@@ -546,7 +546,6 @@ a:hover, a:active {
 	display: block;
   margin: 0 auto;
 	max-width: 720px;
-  text-align: center;
 }
 
 .main-navigation ul {
@@ -581,24 +580,25 @@ a:hover, a:active {
 
 .main-navigation ul li:hover > ul,
 .main-navigation ul li.focus > ul {
+  display: block;
 	left: auto;
 }
 
 .main-navigation li {
-	display: inline;
-  margin-left: 20px;
 	position: relative;
 }
 
 .main-navigation a {
-	display: inline;
+	display: block;
 	text-decoration: none;
 }
 
-/* Small menu. */
-.menu-toggle,
-.main-navigation.toggled ul {
-	display: block;
+@media screen and (max-width: 37.5em) {
+	/* Small menu. */
+	.menu-toggle,
+	.main-navigation.toggled ul {
+		display: block;
+	}
 }
 
 @media screen and (min-width: 37.5em) {
@@ -606,8 +606,14 @@ a:hover, a:active {
 		display: none;
 	}
 	.main-navigation ul {
-		display: block;
-	}
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  
+  .main-navigation a {
+    padding: 0 .5em;
+  }
 }
 
 .site-main .comment-navigation, .site-main

--- a/style.css
+++ b/style.css
@@ -31,7 +31,6 @@ Nicolas Gallagher and Jonathan Neal http://necolas.github.io/normalize.css/
 	## Menus
 # Accessibility
 # Alignments
-# Clearings
 # Widgets
 # Content
 	## Posts and pages
@@ -698,34 +697,6 @@ a:hover, a:active {
   margin-right: auto;
 }
 
-/*--------------------------------------------------------------
-# Clearings
---------------------------------------------------------------*/
-.clear:before,
-.clear:after,
-.entry-content:before,
-.entry-content:after,
-.comment-content:before,
-.comment-content:after,
-.site-header:before,
-.site-header:after,
-.site-content:before,
-.site-content:after,
-.site-footer:before,
-.site-footer:after {
-  content: "";
-  display: table;
-  table-layout: fixed;
-}
-
-.clear:after,
-.entry-content:after,
-.comment-content:after,
-.site-header:after,
-.site-content:after,
-.site-footer:after {
-  clear: both;
-}
 
 /*--------------------------------------------------------------
 # Widgets

--- a/style.css
+++ b/style.css
@@ -616,9 +616,9 @@ a:hover, a:active {
   }
 }
 
-.site-main .comment-navigation, .site-main
-.posts-navigation, .site-main
-.post-navigation {
+.site-main .comment-navigation,
+.site-main .posts-navigation,
+.site-main .post-navigation {
   border-bottom: 1px solid #111;
 	margin: 0 auto 60px;
   max-width: 720px;
@@ -626,19 +626,22 @@ a:hover, a:active {
   padding-bottom: 60px;
 }
 
+.nav-links {
+	display: flex;
+}
+
 .comment-navigation .nav-previous,
 .posts-navigation .nav-previous,
 .post-navigation .nav-previous {
-	float: left;
 	width: 50%;
+	flex: 1 0 50%;
 }
 
 .comment-navigation .nav-next,
 .posts-navigation .nav-next,
 .post-navigation .nav-next {
-	float: right;
-	text-align: right;
-	width: 50%;
+	text-align: end;
+	flex: 1 0 50%;
 }
 
 /*--------------------------------------------------------------

--- a/style.css
+++ b/style.css
@@ -672,7 +672,7 @@ a:hover, a:active {
 }
 
 /* Do not show the outline on the skip link target. */
-#content[tabindex="-1"]:focus {
+#primary[tabindex="-1"]:focus {
   outline: 0;
 }
 


### PR DESCRIPTION
There are no global layout components in the theme as of yet, so there is no clear need for CSS grid to be implemented. This PR therefore prepares the major theme components for eventual layout using CSS grid by removing superfluous nesting containers used to create float-based layouts and cleaning up the semantic markup structure. 

## Changes:
- `#content` div removed
- `#primary` container removed
- `<main>` element given new ID `#primary`
- `skip-to-content` link points at `#primary`
- All default clearfixes removed as pseudo elements register as children of grid/flex containers. Clearings should be applied at component level when necessary.
- Main navigation layout using `flex`
- Posts, post, and comments navigation layout using `flex`

## Related Issues
#27 