### PR TITLE
Add embed wrappers

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -103,7 +103,7 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   padding: .5em;
 }
 
-.entry-content li{
+.entry-content li {
   list-style-position: outside;
 }
 

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -11,7 +11,8 @@
 .wp-block-cover-text,
 .wp-block-button,
 .wp-block-gallery,
-.wp-block-table{
+.wp-block-table,
+.wp-block-embed {
   margin: 1.5em auto;
   max-width: 740px;
   padding-left: 20px;
@@ -110,7 +111,7 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   .wp-block-button,
   .wp-block-gallery,
   .wp-block-table,
-  .wp-block-embed{
+  .wp-block-embed {
     padding-left: 0px;
     padding-right: 0px;
   }

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -12,7 +12,12 @@
 .wp-block-button,
 .wp-block-gallery,
 .wp-block-table,
-.wp-block-embed {
+.wp-block-embed,
+.wp-block-audio,
+.wp-block-pullquote,
+.wp-block-preformatted,
+.wp-block-code,
+.wp-block-verse {
   margin: 1.5em auto;
   max-width: 740px;
   padding-left: 20px;
@@ -37,7 +42,12 @@
 .wp-block-gallery.alignwide,
 .wp-block-table.alignwide,
 .wp-block-embed.alignwide,
-.entry-content p.alignwide {
+.entry-content p.alignwide,
+.wp-block-audio.alignwide,
+.wp-block-pullquote.alignwide,
+.wp-block-preformatted.alignwide,
+.wp-block-code.alignwide,
+.wp-block-verse.alignwide {
   margin: 1.5em auto;
   max-width: 1100px;
 }
@@ -49,7 +59,12 @@
 .wp-block-gallery.alignfull,
 .wp-block-table.alignfull,
 .wp-block-embed.alignfull,
-.entry-content p.alignfull {
+.entry-content p.alignfull,
+.wp-block-audio.alignefull,
+.wp-block-pullquote.alignefull,
+.wp-block-preformatted.alignefull,
+.wp-block-code.alignefull,
+.wp-block-verse.alignefull {
   margin: 1.5em 0;
   max-width: 100%;
 }
@@ -111,7 +126,9 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   .wp-block-button,
   .wp-block-gallery,
   .wp-block-table,
-  .wp-block-embed {
+  .wp-block-embed,
+  .wp-block-audio,
+  .wp-block-pullquote {
     padding-left: 0px;
     padding-right: 0px;
   }

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -35,7 +35,8 @@
 .wp-block-text-columns.alignwide,
 .wp-block-gallery.alignwide,
 .wp-block-table.alignwide,
-.entry-content p.alignwide{
+.wp-block-embed.alignwide,
+.entry-content p.alignwide {
   margin: 1.5em auto;
   max-width: 1100px;
 }
@@ -46,9 +47,15 @@
 .wp-block-text-columns.alignfull
 .wp-block-gallery.alignfull,
 .wp-block-table.alignfull,
-.entry-content p.alignfull{
+.wp-block-embed.alignfull,
+.entry-content p.alignfull {
   margin: 1.5em 0;
   max-width: 100%;
+}
+
+.wp-block-image img {
+  display: block;
+  width: 100%;
 }
 
 .wp-block-gallery:not(.components-placeholder) {
@@ -102,8 +109,26 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   .wp-block-cover-text,
   .wp-block-button,
   .wp-block-gallery,
-  .wp-block-table{
+  .wp-block-table,
+  .wp-block-embed{
     padding-left: 0px;
     padding-right: 0px;
   }
+}
+
+.wp-block-embed.type-video > .wp-block-embed__wrapper {
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-top: 56.25%;
+}
+
+.wp-block-embed.type-video > .wp-block-embed__wrapper > iframe {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }


### PR DESCRIPTION
These styles help fix the issue where embedded content falls outside of the layout.

Lines 120-135 anticipate this PR for bringing in classes for embed types(https://github.com/WordPress/gutenberg/pull/4118) and Gutenberg updating to create parity between the editor view of an embedded block vs the front-end saved view where the is a `<div class="wp-block-embed__wrapper">` inside the `<figure>` which is a necessary piece to maintain the aspect ratio for videos.