### PR TITLE
Fix floats

### DIFF
--- a/style.css
+++ b/style.css
@@ -610,7 +610,7 @@ a:hover, a:active {
     justify-content: center;
     flex-wrap: wrap;
   }
-  
+
   .main-navigation a {
     padding: 0 .5em;
   }
@@ -687,14 +687,36 @@ a:hover, a:active {
 /*--------------------------------------------------------------
 # Alignments
 --------------------------------------------------------------*/
-.alignleft {
-  display: inline;
+
+.alignleft,
+.alignright {
+	max-width: 740px !important;	/* Let's work to make this !important unnecessary */
+}
+
+.alignleft img,
+.alignright img,
+.alignleft figcaption,
+.alignright figcaption {
+	max-width: 50%;
+	width: 50%;
+}
+
+.alignleft figcaption {
+	clear: left;
+	float: left;
+}
+
+.alignright figcaption {
+	clear: right;
+	float: right;
+}
+
+.alignleft img {
   float: left;
   margin-right: 1.5em;
 }
 
-.alignright {
-  display: inline;
+.alignright img {
   float: right;
   margin-left: 1.5em;
 }


### PR DESCRIPTION
Starts work at #39.

This PR makes floats work in Gutenberg Starter Theme, right alongside wide and fullwide images. Captions work too. Before:

<img width="1279" alt="screen shot 2018-03-07 at 10 03 51" src="https://user-images.githubusercontent.com/1204802/37083958-6b588d2a-21f1-11e8-99a2-b7a722a1b7cf.png">

After:

![after](https://user-images.githubusercontent.com/1204802/37083960-6da76538-21f1-11e8-91e2-3fe729c00ff7.gif)

However due to the addition of the inline max-width style added by Gutenberg, this PR features an !important modifier. We should strive to make changes to Gutenberg upstream, so that this is not necesary. While potentially we could find a different way to combine floats with wide and fullwide images (see https://themeshaper.com/2018/02/15/styling-themes-for-gutenberg/), the method used in this PR (based on https://codepen.io/joen/pen/oEYVXB?editors=1100) is fairly elegant in that (aside from captions) reduces complexity and the need to hide horizontal scrollbars occurring from the `vw` unit.

There are two issues at the core of it. 

**The first** is that the `figure` element, which is a semantic element for wrapping images and captions, has no intrinsic width like the `img` has. That means unless we explicitly set a width on this element, it will default to filling the full available space. This is why Gutenberg adds a `max-width` to a floated `figure`, to essentially take some burden off of theme devs. 

You could potentially make the `figure` element be `inline`, but then you wouldn't be able to center captions below the image. You also wouldn't be able to use [this method](https://codepen.io/joen/pen/oEYVXB?editors=1100) for having wide images and floats coexist, you'd have to use something like the `vw` approach. 

Upstream, this is tracked in https://github.com/WordPress/gutenberg/issues/5292, and is also discussed in depth in this PR: https://github.com/WordPress/gutenberg/pull/5209#issuecomment-367957818

Unless we rethink how floats behave in a gutenberg/wide images world, I feel like the best approach is what is taken in this PR: https://github.com/WordPress/gutenberg/pull/5460 — it basically adds additional markup to floated images (essentially fixing https://github.com/WordPress/gutenberg/issues/5292). It's not as pretty, it's not semantic, and if a better idea surfaced I'd probably prefer that. But as it stands that's my best bet at how to proceed.