### PR TITLE
Changed "page-" prefix to "entry-" in 404 template to receive styles for centering on page

### DIFF
--- a/404.php
+++ b/404.php
@@ -8,15 +8,15 @@
  */
 
 get_header(); ?>
-	
+
 	<main id="primary" class="site-main">
 
 		<section class="error-404 not-found">
-			<header class="page-header">
-				<h1 class="page-title"><?php esc_html_e( 'Oops! That page can&rsquo;t be found.', 'gutenbergtheme' ); ?></h1>
+			<header class="entry-header">
+				<h1 class="entry-title"><?php esc_html_e( 'Oops! That page can&rsquo;t be found.', 'gutenbergtheme' ); ?></h1>
 			</header><!-- .page-header -->
 
-			<div class="page-content">
+			<div class="entry-content">
 				<p><?php esc_html_e( 'It looks like nothing was found at this location. Maybe try one of the links below or a search?', 'gutenbergtheme' ); ?></p>
 
 				<?php


### PR DESCRIPTION
It may be that I missed something here, but I think that the page-header, page-content (and maybe page-title) used in the 404.php should be replaced with entry-header, entry-content, etc.

The reason for this is that the .page- classes do not receive the main centering styles.

Another approach could be just adding those classes already used in the 404.php template to something like this:

https://github.com/WordPress/gutenberg-starter-theme/blob/master/style.css#L792

Hope this helps (if it was actually needed)!