### PR TITLE
Add theme support for wp-block-styles

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -80,6 +80,9 @@ if ( ! function_exists( 'gutenbergtheme_setup' ) ) :
 			'flex-height' => true,
 		) );
 
+		// Adding support for core block visual styles.
+		add_theme_support( 'wp-block-styles' );
+
 		// Add support for full and wide align images.
 		add_theme_support( 'align-wide' );
 


### PR DESCRIPTION
This PR opts-in to visual styles for core blocks. This option was added to Gutenberg via https://github.com/WordPress/gutenberg/pull/6947 and is documented [here](https://wordpress.org/gutenberg/handbook/extensibility/theme-support/#default-block-styles). It'll be present in Gutenberg [v3.0](https://github.com/WordPress/gutenberg/milestone/54). 

The file it loads in (`theme.css`) is mostly empty for now, but will be populated as more core blocks styles are imported over to it ([Example](https://github.com/WordPress/gutenberg/pull/7062)).

**Testing:**

Activate the theme, and visit any post/page. Use the Network tab of your browser's dev tools to verify that the `theme.css` file is being loaded in:

<img width="493" alt="screen shot 2018-06-01 at 1 18 02 pm" src="https://user-images.githubusercontent.com/1202812/40854158-84b35fc0-659e-11e8-87b4-9e8e49aacebd.png">

_Note that you must be using Gutenberg v3.0 (or the latest from the Gutenberg repo) for this to have any effect. There's probably no use in merging this until v3.0 launches._