### PR TITLE
Update wp-block-separator styles

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -83,6 +83,7 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 .wp-block-separator {
   max-width: 100px;
   margin: 3em auto;
+  padding: 0;
 }
 
 @media screen and (min-width: 768px) {

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -80,6 +80,10 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   right: 0;
 }
 
+.wp-block-separator {
+  max-width: 100px;
+}
+
 @media screen and (min-width: 768px) {
   .wp-block-cover-text p {
     padding: 1.5em 0;

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -82,6 +82,7 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 
 .wp-block-separator {
   max-width: 100px;
+  margin: 3em auto;
 }
 
 @media screen and (min-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -379,7 +379,6 @@ blockquote, q {
     content: ""; }
 
 hr {
-  background-color: #ccc;
   border: 0;
   height: 1px;
   margin-bottom: 1.5em;


### PR DESCRIPTION
A few theme styles are overriding default separator block styles. This PR aims to fix that, while also adding some extra margin to better align this visually with what you see in the editor. 

**Before:** 
---
<img width="812" alt="screen shot 2018-06-01 at 1 45 39 pm" src="https://user-images.githubusercontent.com/1202812/40855373-6b15114a-65a2-11e8-84a7-aeb6f5a98c04.png">

**After:**
---
<img width="845" alt="screen shot 2018-06-01 at 1 43 23 pm" src="https://user-images.githubusercontent.com/1202812/40855420-88e470a8-65a2-11e8-87d7-7ee1724f6e97.png">