### PR TITLE
Update H1–H6 font sizes to match Gutenberg

### DIFF
--- a/style.css
+++ b/style.css
@@ -109,8 +109,28 @@ dfn {
 }
 
 h1 {
-  font-size: 2em;
+  font-size: 2.44em;
   margin: 0.67em 0;
+}
+
+h2 {
+  font-size: 1.95em;
+}
+
+h3 {
+  font-size: 1.56em;
+}
+
+h4 {
+  font-size: 1.25em;
+}
+
+h5 {
+  font-size: 1em;
+}
+
+h6 {
+  font-size: 0.8em;
 }
 
 mark {
@@ -276,8 +296,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .entry-header h1.entry-title {
-  font-size: 32px;
-  font-size: 2rem;
+  font-size: 2.44em;
   line-height: 1.4;
   margin: 1em 0;
 }


### PR DESCRIPTION
This PR updates the font sizes for `h1`, `h2`, `h3`, `h4`, `h5`, and `h6` to match the type scale used in Gutenberg ([reference](https://github.com/WordPress/gutenberg/blob/eabf6821c76d56bbbc00dd70f6d539b9199fbe67/core-blocks/heading/editor.scss#L11)). 

Previously, we used an incorrect size for `h1`, and the rest were just the browser default. 