### PR TITLE
Update content width to match Gutenberg.

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -1,6 +1,6 @@
 .entry-content > * {
   margin: 1.5em auto;
-  max-width: 740px;
+  max-width: 636px;
   padding-left: 20px;
   padding-right: 20px;
 }
@@ -17,12 +17,12 @@
 .entry-content ul,
 .entry-content ol {
   margin: 1.5em auto;
-  max-width: 740px;
+  max-width: 636px;
   list-style-position: outside;
 }
 
 .wp-block-video video {
-  max-width: 740px;
+  max-width: 636px;
 }
 
 .wp-block-image img {

--- a/style.css
+++ b/style.css
@@ -545,7 +545,7 @@ a:hover, a:active {
 	clear: both;
 	display: block;
   margin: 0 auto;
-	max-width: 720px;
+	max-width: 636px;
 }
 
 .main-navigation ul {
@@ -621,7 +621,7 @@ a:hover, a:active {
 .site-main .post-navigation {
   border-bottom: 1px solid #111;
 	margin: 0 auto 60px;
-  max-width: 720px;
+  max-width: 636px;
 	overflow: hidden;
   padding-bottom: 60px;
 }
@@ -796,7 +796,7 @@ a:hover, a:active {
 .page-navigation,
 .comments-area {
   margin: 1.5em auto;
-  max-width: 720px;
+  max-width: 636px;
 }
 
 .entry-footer span{


### PR DESCRIPTION
The stylesheet imposes a maximum content width of `740px` (`720px` in some areas). 

This PR updates that to `636px`, to match the width in Gutenberg ([reference](https://github.com/WordPress/gutenberg/blob/5a57e6fdda6e2d4f1380e391a78cbb463a77215e/edit-post/assets/stylesheets/_variables.scss#L36)). It also updates the `max-width` of the navigation to the same value for consistency. 