### PR TITLE
Adjusting block margins to mimic Gutenberg.

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -1,5 +1,5 @@
 .entry-content > * {
-  margin: 1.5em auto;
+  margin: 36px auto;
   max-width: 740px;
   padding-left: 20px;
   padding-right: 20px;


### PR DESCRIPTION
Vertical block margins in Gutenberg are uniform. Block spacing in the theme is currently set to `1.5em`. Due to the nature of `em` units, the spacing varies depending on the font size in the block. This causes inconsistencies in the way blocks are spaced:

![baselines](https://user-images.githubusercontent.com/1202812/40859341-6f19114e-65af-11e8-83b5-ef29c57f0ab3.png)

This PR fixes that so that by setting the spacing to `36px`. This more accurately mimics the spacing in Gutenberg. 