### PR TITLE
Setting the width of alignfull images to 100vw

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -30,6 +30,10 @@
   width: 100%;
 }
 
+.wp-block-image.alignfull img {
+  width: 100vw;
+}
+
 .wp-block-gallery:not(.components-placeholder) {
   margin: 1.5em auto;
 }


### PR DESCRIPTION
On the front end, `alignfull` image width is set to 100%, which maxes out at the width of the image itself. This is likely in place to prevent pixellated/blurry images on larger screens. 

Unfortunately, this appears broken in practice — even on the default Gutenberg demo: 

> ![gutenberg test_ 1](https://user-images.githubusercontent.com/1202812/40925607-201d5484-67e8-11e8-8903-acfa0229845d.png)

The Gutenberg editor stretches `alignfull` images to `100vw` even if it makes them blurry, so I suggest we adopt that here too. This PR makes that change: 

> ![gutenberg test_](https://user-images.githubusercontent.com/1202812/40925732-5dbf15c0-67e8-11e8-8437-fa8353ae516b.jpg)

