### PR TITLE
Removing top margin from the first paragraph of a pullquote.

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -80,6 +80,10 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   right: 0;
 }
 
+.wp-block-pullquote>p:first-child {
+  margin-top: 0;
+}
+
 .wp-block-separator {
   max-width: 100px;
   margin: 3em auto;


### PR DESCRIPTION
Text inside of pullquote blocks is not properly centered vertically. This PR fixes this by removing the top margin of the first `p` inside of the pullquote. 

![](https://user-images.githubusercontent.com/1202812/40933457-7dcf8554-67ff-11e8-8fa6-0a589b76f7e8.png)

(In the editor, this is handled by [tinymce styles](https://github.com/WordPress/gutenberg/blob/5f5ae541d30d4670da0e3118e5e71517fe0692d0/editor/components/rich-text/style.scss#L15), not by block-level styles. But this is — so far — the only issue where I've seen this come up on the front-end.)
