### PR TITLE
Fix non-rendering resized images.

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -27,7 +27,6 @@
 
 .wp-block-image img {
   display: block;
-  width: 100%;
 }
 
 .wp-block-gallery:not(.components-placeholder) {


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg-starter-theme/issues/45

Resized (and non-captioned) images currently disappear on the front-end. This is because the image block uses `min-content` to make sure the width of captions don't exceed the width of images ([reference](https://github.com/WordPress/gutenberg/blob/2b5448def003b3e7ba6531e8c5a65bde20cb14bb/core-blocks/image/style.scss#L19)). This property value breaks when the only child of the `wp-block-image` uses a percentage width.

It turns out we don't actually need the width of all images to be set to 100% (at least as far as I can tell), so we should be able to remove this and fix that issue.

To test:

1. Create a new post.
2. Insert an image with no caption.
3. Resize the image to any size.
4. Save and publish the post.
5. Verify that on the front end, the image renders.
6. Verify that other image blocks don't look broken now. 🙂