### PR TITLE
Update footer credit with correct theme name

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -15,12 +15,12 @@
 	<div class="site-info">
 		<a href="<?php echo esc_url( __( 'https://wordpress.org/', '_s' ) ); ?>"><?php
 			/* translators: %s: CMS name, i.e. WordPress. */
-			printf( esc_html__( 'Proudly powered by %s', '_s' ), 'WordPress' );
+			printf( esc_html__( 'Proudly powered by %s', 'gutenbergtheme' ), 'WordPress' );
 		?></a>
 		<span class="sep"> | </span>
 		<?php
 			/* translators: 1: Theme name, 2: Theme author. */
-			printf( esc_html__( 'Theme: %1$s by %2$s.', '_s' ), '_s', '<a href="https://automattic.com/">Automattic</a>' );
+			printf( esc_html__( 'Theme: %s', 'gutenbergtheme' ), '<a href="https://github.com/WordPress/gutenberg-starter-theme/">Gutenberg</a>' );
 		?>
 	</div><!-- .site-info -->
 </footer><!-- #colophon -->


### PR DESCRIPTION
The theme's footer currently displays the default `_s by Automattic` footer credit.

<img width="508" alt="screen shot 2018-06-05 at 11 16 34 am" src="https://user-images.githubusercontent.com/1202812/40986168-94cc4d32-68b3-11e8-8a8a-30a72db5cb64.png">

This PR updates that to:
> Theme: [Gutenberg](https://github.com/WordPress/gutenberg-starter-theme/)

It also updates the text domains for the footer translations. 