### PR TITLE
Enqueue Noto Serif

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -130,7 +130,7 @@ function gutenbergtheme_fonts_url() {
 
 	/*
 	 *Translators: If there are characters in your language that are not
-	 * supported by Karla, translate this to 'off'. Do not translate
+	 * supported by Noto Serif, translate this to 'off'. Do not translate
 	 * into your own language.
 	 */
 	$notoserif = esc_html_x( 'on', 'Noto Serif font: on or off', 'gutenbergtheme' );

--- a/functions.php
+++ b/functions.php
@@ -159,6 +159,8 @@ function gutenbergtheme_scripts() {
 
 	wp_enqueue_style( 'gutenbergthemeblocks-style', get_template_directory_uri() . '/css/blocks.css' );
 
+	wp_enqueue_style( 'gutenbergtheme-fonts', gutenbergtheme_fonts_url() );
+
 	wp_enqueue_script( 'gutenbergtheme-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '20151215', true );
 
 	wp_enqueue_script( 'gutenbergtheme-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );


### PR DESCRIPTION
We're currently generating the custom font URL for Noto Serif through the `gutenbergtheme_fonts_url()` function ([reference](https://github.com/WordPress/gutenberg-starter-theme/blob/master/functions.php#L128)), but we're not actually enqueuing the font anywhere. Therefore, the font doesn't actually load in. This issue has been observed in #31 and #44.

This PR enqueues the font. 