### PR TITLE
Small screens visual cleanup

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -1,8 +1,8 @@
 .entry-content > * {
   margin: 36px auto;
   max-width: 636px;
-  padding-left: 20px;
-  padding-right: 20px;
+  padding-left: 14px;
+  padding-right: 14px;
 }
 
 .entry-content > .alignwide {
@@ -38,14 +38,14 @@
 }
 
 .wp-block-cover-text p {
-  padding: 1.5em 20px;
+  padding: 1.5em 14px;
 }
 
 ul.wp-block-latest-posts.alignwide,
 ul.wp-block-latest-posts.alignfull,
 ul.wp-block-latest-posts.is-grid.alignwide,
 ul.wp-block-latest-posts.is-grid.alignwide {
-  padding: 0 20px;
+  padding: 0 14px;
 }
 
 .wp-block-table {

--- a/style.css
+++ b/style.css
@@ -814,6 +814,8 @@ a:hover, a:active {
 .page-navigation,
 .comments-area {
   margin: 1.5em auto;
+  padding-left: 20px;
+  padding-right: 20px;
   max-width: 636px;
 }
 
@@ -824,8 +826,20 @@ a:hover, a:active {
 .entry-footer{
   color: #aaa;
   font-size: 90%;
-  padding: 0 0 40px 0;
+  padding-bottom: 40px;
   border-bottom: 1px solid #111;
+}
+
+@media screen and (min-width: 676px) {
+  .entry-header,
+  .entry-footer,
+  .site-info,
+  .post-navigation,
+  .page-navigation,
+  .comments-area {
+    padding-left: 0;
+    padding-right: 0;
+  }
 }
 
 /*--------------------------------------------------------------

--- a/style.css
+++ b/style.css
@@ -616,6 +616,7 @@ a:hover, a:active {
 	.menu-toggle,
 	.main-navigation.toggled ul {
 		display: block;
+    margin: 0 auto;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -564,6 +564,7 @@ a:hover, a:active {
 	display: block;
   margin: 0 auto;
 	max-width: 636px;
+  text-align: center;
 }
 
 .main-navigation ul {
@@ -609,6 +610,10 @@ a:hover, a:active {
 .main-navigation a {
 	display: block;
 	text-decoration: none;
+}
+
+.menu-toggle {
+  padding: 1em;
 }
 
 @media screen and (max-width: 37.5em) {

--- a/style.css
+++ b/style.css
@@ -820,8 +820,8 @@ a:hover, a:active {
 .page-navigation,
 .comments-area {
   margin: 1.5em auto;
-  padding-left: 20px;
-  padding-right: 20px;
+  padding-left: 14px;
+  padding-right: 14px;
   max-width: 636px;
 }
 
@@ -836,7 +836,7 @@ a:hover, a:active {
   border-bottom: 1px solid #111;
 }
 
-@media screen and (min-width: 676px) {
+@media screen and (min-width: 664px) {
   .entry-header,
   .entry-footer,
   .site-info,

--- a/style.css
+++ b/style.css
@@ -581,6 +581,7 @@ a:hover, a:active {
 	top: 100%;
 	left: -999em;
 	z-index: 99999;
+  text-align: left;
 }
 
 .main-navigation ul ul ul {


### PR DESCRIPTION
I recently came across a few minor small bugs on smaller screens. Most of these aren't specifically related to blocks, but they do look broken. 

- The `menu-toggle` button has unequal padding around it. 
- The `menu-toggle` button and menu items are pushed up against the left side of the screen.
- Items inside of `entry-content` have `20px` of padding on the left and right, whereas that padding in the Gutenberg editor is `14px`. 
- Most items outside of entry-content have no left/right padding at all — they bump right up against the side of the screen.

![before](https://user-images.githubusercontent.com/1202812/40993131-bfdff790-68c6-11e8-82f8-c99ac7fcd243.gif)

---

This PR fixes those issues:

- It adds `1em` of padding all around the `menu-toggle` button.
- It center-aligns the menu button and menu items.
- It changes the `20px` padding to `14px` throughout `entry-content`.
- It adds `14px` of left + right padding to elements like the `entry-header`, `entry-footer`, etc.

![after](https://user-images.githubusercontent.com/1202812/40993134-c310494c-68c6-11e8-927e-afa38efe93f1.gif)