### PR TITLE
Set left and right margins of Quote Style 2 blocks to auto.

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -83,6 +83,10 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   right: 0;
 }
 
+.wp-block-quote.is-large {
+  margin: 0 auto 16px;
+}
+
 .wp-block-pullquote>p:first-child {
   margin-top: 0;
 }


### PR DESCRIPTION
By default, Quote Style 2 blocks have left/right margins of `0`, which overrides the `auto` margins we declare on [L2 of blocks.css](https://github.com/WordPress/gutenberg-starter-theme/blob/master/css/blocks.css#L2). This causes them to bump up against the side of the screen, rather than remain in the middle like they're supposed to:


> <img width="1105" alt="screen shot 2018-06-05 at 2 12 30 pm" src="https://user-images.githubusercontent.com/1202812/40995591-6f8c8414-68cd-11e8-8bc0-a30fff22716f.png">

This PR fixes that by using a more specific class selector in `blocks.css` to assign `auto` left/right margins. 

> <img width="1105" alt="screen shot 2018-06-05 at 2 12 12 pm" src="https://user-images.githubusercontent.com/1202812/40995620-8c3be5be-68cd-11e8-9595-d25caa9f0000.png">
