### PR TITLE
Get floated images working as expected. 

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -29,6 +29,11 @@
   display: block;
 }
 
+.wp-block-image.alignleft.is-resized,
+.wp-block-image.alignright.is-resized {
+  width: 100%
+}
+
 .wp-block-image.alignfull img {
   width: 100vw;
 }

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -29,8 +29,8 @@
   display: block;
 }
 
-.wp-block-image.alignleft.is-resized,
-.wp-block-image.alignright.is-resized {
+.wp-block-image.alignleft,
+.wp-block-image.alignright {
   width: 100%
 }
 

--- a/style.css
+++ b/style.css
@@ -708,7 +708,7 @@ a:hover, a:active {
 
 .alignleft,
 .alignright {
-	max-width: 740px !important;	/* Let's work to make this !important unnecessary */
+	max-width: 636px !important;	/* Let's work to make this !important unnecessary */
 }
 
 .alignleft img,
@@ -721,20 +721,20 @@ a:hover, a:active {
 
 .alignleft figcaption {
 	clear: left;
-	float: left;
 }
 
 .alignright figcaption {
 	clear: right;
-	float: right;
 }
 
-.alignleft img {
+.alignleft img,
+.alignleft figcaption {
   float: left;
   margin-right: 1.5em;
 }
 
-.alignright img {
+.alignright img,
+.alignright figcaption {
   float: right;
   margin-left: 1.5em;
 }


### PR DESCRIPTION
Currently, floated images are broken:

- They have giant margins. 
- Resized images look really tiny.
- Captions don't share the same margins as the images themselves, so text wraps oddly around them. 

> ![gutenberg test__p 24](https://user-images.githubusercontent.com/1202812/41106837-ed9fa36e-6a3e-11e8-8e2a-5eb3f43a3f25.png) 

This PR fixes that:

> ![gutenberg test__p 24 1](https://user-images.githubusercontent.com/1202812/41106894-14df72d8-6a3f-11e8-8833-b06cf894e7e9.png)

There is one caveat though — The theme imposes [a 50% width](https://github.com/WordPress/gutenberg-starter-theme/pull/40/commits/6f6befcea655b8477e049f205a93df3e1f4ded3e#diff-da232d78aa810382f2dcdceae308ff8eR701) on all floated images, as per @jasmussen's commits in https://github.com/WordPress/gutenberg-starter-theme/pull/40. Unfortunately, this means that we ignore the custom dimensions of all images. :/ 

We can theoretically remove this and everything works _mostly_ fine. The only remaining bug is the image captions. I can't find a graceful way to make those captions mirror the width of the image above them:

> ![gutenberg test__p 24 2](https://user-images.githubusercontent.com/1202812/41108067-9e6e4806-6a41-11e8-9105-4745bb0ed8f1.png)

@jasmussen (or anyone else), I wonder if you have any suggestions for how we should handle this? 
