### PR TITLE
Revise list styles to match Gutenberg.

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -68,7 +68,7 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 }
 
 .entry-content li {
-  margin-left: 3.5em;
+  margin-left: 2.5em;
   margin-bottom: 6px;
 }
 

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -68,8 +68,24 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 }
 
 .entry-content li {
-  list-style-position: outside;
+  margin-left: 3.5em;
+  margin-bottom: 6px;
 }
+
+.entry-content ul ul,
+.entry-content ol ol,
+.entry-content ul ol,
+.entry-content ol ul {
+  margin: 0 auto;
+}
+
+.entry-content ul ul li,
+.entry-content ol ol li,
+.entry-content ul ol li,
+.entry-content ol ul li {
+  margin-left: 0;
+}
+
 
 .wp-block-embed.type-video > .wp-block-embed__wrapper {
   position: relative;


### PR DESCRIPTION
This PR revises some `ul` and `ol` margins to match the visual display in Gutenberg.

![artboard](https://user-images.githubusercontent.com/1202812/41160819-c5036ccc-6afe-11e8-8e7f-09a0074b5b33.png)