### PR TITLE
Update 404 + search page styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -815,11 +815,14 @@ a:hover, a:active {
 }
 
 .entry-header,
+.page-header,
 .entry-footer,
 .site-info,
 .post-navigation,
 .page-navigation,
-.comments-area {
+.comments-area,
+.not-found .page-content,
+.search .entry-summary {
   margin: 1.5em auto;
   padding-left: 14px;
   padding-right: 14px;
@@ -839,11 +842,14 @@ a:hover, a:active {
 
 @media screen and (min-width: 664px) {
   .entry-header,
+  .page-header,
   .entry-footer,
   .site-info,
   .post-navigation,
   .page-navigation,
-  .comments-area {
+  .comments-area,
+  .not-found .page-content,
+  .search .entry-summary {
     padding-left: 0;
     padding-right: 0;
   }


### PR DESCRIPTION
This PR updates 404 + search page styles so that everything is centered correctly in the main content column. This tackles the same problem as #42, but addresses the search page too. I decided to do this via CSS, since it felt like more of a style issue than structure issue. 

(Thanks @zgordon for highlighting the issue!)

Before:
> <img width="1440" alt="screen shot 2018-06-08 at 10 39 20 am" src="https://user-images.githubusercontent.com/1202812/41164128-706314b0-6b08-11e8-9690-61bdc3cca8b0.png">
> <img width="1440" alt="screen shot 2018-06-08 at 10 39 36 am" src="https://user-images.githubusercontent.com/1202812/41164151-76750cf0-6b08-11e8-925b-13c52e4a2b66.png">
> <img width="1440" alt="screen shot 2018-06-08 at 10 39 58 am" src="https://user-images.githubusercontent.com/1202812/41164157-7c0e1d5a-6b08-11e8-8749-9242b8245536.png">

After:
> <img width="1440" alt="screen shot 2018-06-08 at 10 40 43 am" src="https://user-images.githubusercontent.com/1202812/41164171-847187b6-6b08-11e8-914d-64ba85b95542.png">
> <img width="1440" alt="screen shot 2018-06-08 at 10 40 32 am" src="https://user-images.githubusercontent.com/1202812/41164175-884347d0-6b08-11e8-9dd9-effb6efaa257.png">
> <img width="1440" alt="screen shot 2018-06-08 at 10 40 18 am" src="https://user-images.githubusercontent.com/1202812/41164183-8be97580-6b08-11e8-8327-901b87b8e5ad.png">

