### PR TITLE
Remove max-width for separators.

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -97,7 +97,6 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 }
 
 .wp-block-separator {
-  max-width: 100px;
   margin: 3em auto;
   padding: 0;
 }


### PR DESCRIPTION
This PR removes the `max-width` declaration for Separator blocks. Once the `max-width` is [defined in Gutenberg's theme.css](https://github.com/WordPress/gutenberg/pull/7362/files#diff-37ba0f2ba01255e2883d20844d2e68e3) (as part of https://github.com/WordPress/gutenberg/pull/7362/), we won't want to override it here in the theme.