### PR TITLE
Use updated theme supports for defining editor colors

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -87,24 +87,28 @@ if ( ! function_exists( 'gutenbergtheme_setup' ) ) :
 		add_theme_support( 'align-wide' );
 
 		// Add support for custom color scheme.
-		add_theme_support( 'editor-color-palette',
+		add_theme_support( 'editor-color-palette', array(
 			array(
-				'name' => 'strong blue',
+				'name'  => 'strong blue',
+				'slug'  => 'strong-blue',
 				'color' => '#0073aa',
 			),
 			array(
-				'name' => 'lighter blue',
+				'name'  => 'lighter blue',
+				'slug'  => 'lighter-blue',
 				'color' => '#229fd8',
 			),
 			array(
-				'name' => 'very light gray',
+				'name'  => 'very light gray',
+				'slug'  => 'very-light-gray',
 				'color' => '#eee',
 			),
 			array(
-				'name' => 'very dark gray',
+				'name'  => 'very dark gray',
+				'slug'  => 'very-dark-gray',
 				'color' => '#444',
 			)
-		);
+		) );
 
 	}
 endif;


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/7619

Gutenberg will start noisily logging warnings after the upcoming release without these changes.

cc @webmandesign @jorgefilipecosta 