### PR TITLE
Update custom colors implementation.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -87,22 +87,27 @@ if ( ! function_exists( 'gutenbergtheme_setup' ) ) :
 		add_theme_support( 'align-wide' );
 
 		// Add support for custom color scheme.
-		add_theme_support( 'editor-color-palette',
-			array(
-				'name' => 'strong blue',
-				'color' => '#0073aa',
-			),
-			array(
-				'name' => 'lighter blue',
-				'color' => '#229fd8',
-			),
-			array(
-				'name' => 'very light gray',
-				'color' => '#eee',
-			),
-			array(
-				'name' => 'very dark gray',
-				'color' => '#444',
+		add_theme_support( 'editor-color-palette', array( 
+				array(
+					'name' => __( 'strong blue' ),
+	 				'slug' => 'strong-blue',
+					'color' => '#0073aa',
+				),
+				array(
+					'name' => __( 'lighter blue' ),
+	 				'slug' => 'lighter-blue',
+					'color' => '#229fd8',
+				),
+				array(
+					'name' => __( 'very light gray'),
+					'slug' => 'very-light-gray',
+					'color' => '#eee',
+				),
+				array(
+					'name' => __( 'very dark gray' ),
+					'slug' => 'very-dark-gray',
+					'color' => '#444',
+				)
 			)
 		);
 


### PR DESCRIPTION
The current implementation of custom colors is depreciated.

Theme support for `editor-color-palette` should now include just a single array containing all colors. In addition, each custom color should have a slug defined. This PR makes those changes.

See: https://wordpress.org/gutenberg/handbook/extensibility/theme-support/