### PR TITLE
Prevent bullets from being cut off on smaller screens.

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -17,6 +17,7 @@
 .entry-content ul,
 .entry-content ol {
   margin: 1.5em auto;
+  padding-left: calc( 1.3em + 14px );
   max-width: 636px;
   list-style-position: outside;
 }


### PR DESCRIPTION
Currently, bullets are cut off on smaller screens:

![cut-off](https://user-images.githubusercontent.com/1202812/43049188-5884ead6-8dc1-11e8-955e-5d61bc7d5bb1.gif)


In this theme, `14px` of padding added via [the global declaration at the top of blocks.css](https://github.com/WordPress/gutenberg-starter-theme/blob/master/css/blocks.css#L4). This PR adds 1.3em of padding to that, to prevent the bullets from being cut off. 

(`1.3em` is [the left padding used in Gutenberg](https://github.com/WordPress/gutenberg/blob/5f5ae541d30d4670da0e3118e5e71517fe0692d0/core-blocks/list/editor.scss#L4))