### PR TITLE
Update line height in headings to match Gutenberg.

### DIFF
--- a/style.css
+++ b/style.css
@@ -111,18 +111,22 @@ dfn {
 h1 {
   font-size: 2.44em;
   margin: 0.67em 0;
+  line-height: 1.4;
 }
 
 h2 {
   font-size: 1.95em;
+  line-height: 1.4;
 }
 
 h3 {
   font-size: 1.56em;
+  line-height: 1.4;
 }
 
 h4 {
   font-size: 1.25em;
+  line-height: 1.5;
 }
 
 h5 {


### PR DESCRIPTION
This PR updates the line height for `h1`, `h2`, `h3`, and `h4` to match the new specs defined in https://github.com/WordPress/gutenberg/issues/7930. 

_Before:_
<img width="711" alt="screen shot 2018-07-23 at 8 19 22 am" src="https://user-images.githubusercontent.com/1202812/43076279-b6ed2b7a-8e51-11e8-84f2-f8a8c8f83e06.png">

_After:_
<img width="705" alt="screen shot 2018-07-23 at 8 19 33 am" src="https://user-images.githubusercontent.com/1202812/43076283-bac316a6-8e51-11e8-951d-591a74b741be.png">
