### PR TITLE
Add theme support for responsive embeds.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -109,6 +109,9 @@ if ( ! function_exists( 'gutenbergtheme_setup' ) ) :
 				'color' => '#444',
 			),
 		) );
+
+		// Add support for responsive embeds.
+		add_theme_support( 'responsive-embeds' );
 	}
 endif;
 add_action( 'after_setup_theme', 'gutenbergtheme_setup' );


### PR DESCRIPTION
Ensures that alignfull & alignwide embeds are scaled to take up the space they're given (and that they are responsive 🙂). Here's an example of a YouTube video set to align wide:

**Before:**
<img width="1419" alt="screen shot 2018-11-06 at 8 39 52 am" src="https://user-images.githubusercontent.com/1202812/48068120-f3bb7b00-e19f-11e8-8101-909bc97c8eb2.png">

**After:**
<img width="1418" alt="screen shot 2018-11-06 at 8 39 36 am" src="https://user-images.githubusercontent.com/1202812/48068124-f61dd500-e19f-11e8-9b02-02d369be8590.png">

Related slack discussion: 
https://wordpress.slack.com/archives/C02QB2JS7/p1541469679669900