### PR TITLE
Add a composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+  {
+    "name": "WordPress/gutenberg-starter-theme",
+    "type": "wordpress-theme",
+    "require": {
+        "composer/installers": "^1.0"
+    }
+}


### PR DESCRIPTION
I'd like to be able to install this theme via composer, all that is required is that the theme have a composer.json with the type `wordpress-theme`. 

