### PR TITLE
Add support for section block alignments on the front end.

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -117,6 +117,20 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   padding: 0;
 }
 
+.wp-block-section > * {
+  max-width: 610px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.wp-block-section > .alignwide {
+  max-width: 1100px;
+}
+
+.wp-block-section > .alignfull {
+  max-width: 100%;
+}
+
 @media screen and (min-width: 768px) {
   .wp-block-cover-text p {
     padding: 1.5em 0;

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -131,6 +131,13 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   max-width: 100%;
 }
 
+.wp-block-section.has-background > .alignfull {
+  width: calc( 100% + 60px );
+  max-width: calc( 100% + 60px );
+  position: relative;
+  left: -30px;
+}
+
 @media screen and (min-width: 768px) {
   .wp-block-cover-text p {
     padding: 1.5em 0;


### PR DESCRIPTION
Adds support for wide/full child blocks inside of a section block.

Pending the merge of https://github.com/WordPress/gutenberg/pull/13964 in to Gutenberg. Props @getdave for [the initial code here](https://github.com/WordPress/gutenberg/pull/13964#issuecomment-475217409).

---

**Before** 

![gutenberg test_2019_04_01_section-block_ (1)](https://user-images.githubusercontent.com/1202812/55325160-34b77300-5452-11e9-9c54-08ae66377d55.png)

**After**

![gutenberg test_2019_04_01_section-block_](https://user-images.githubusercontent.com/1202812/55325178-397c2700-5452-11e9-8f75-06788ee44cdb.png)
