### PR TITLE
Rename Section Block to Group Block

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -121,21 +121,21 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 	display: block;
 }
 
-.wp-block-section > * {
+.wp-block-group > * {
   max-width: 610px;
   margin-left: auto;
   margin-right: auto;
 }
 
-.wp-block-section > .alignwide {
+.wp-block-group > .alignwide {
   max-width: 1100px;
 }
 
-.wp-block-section > .alignfull {
+.wp-block-group > .alignfull {
   max-width: 100%;
 }
 
-.wp-block-section.has-background > .alignfull {
+.wp-block-group.has-background > .alignfull {
   width: calc( 100% + 60px );
   max-width: calc( 100% + 60px );
   position: relative;


### PR DESCRIPTION
Renames the "Section" block to "Group" to align with the [new official name](https://github.com/WordPress/gutenberg/pull/14920).