### PR TITLE
Enable a dark editor style via a new Settings panel

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -203,3 +203,8 @@ require get_template_directory() . '/inc/customizer.php';
 if ( defined( 'JETPACK__VERSION' ) ) {
 	require get_template_directory() . '/inc/jetpack.php';
 }
+
+/**
+ * Theme Settings
+ */
+require get_template_directory() . '/inc/theme-options.php';

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -1,0 +1,72 @@
+<?php 
+
+/**
+ * Set up a WP-Admin page for managing turning on and off theme features.
+ */
+function gutenbergtheme_add_options_page() {
+	add_menu_page(
+		'Theme Options',
+		'Theme Options',
+		'manage_options',
+		'gutenbergtheme-options',
+		'gutenbergtheme_options_page'
+	);
+
+	// Call register settings function
+	add_action( 'admin_init', 'gutenbergtheme_options' );
+}
+add_action( 'admin_menu', 'gutenbergtheme_add_options_page' );
+
+
+/**
+ * Register settings for the WP-Admin page.
+ */
+function gutenbergtheme_options() {
+	register_setting( 'gutenbergtheme-options', 'gutenbergtheme-dark-mode' );
+}
+
+
+/**
+ * Build the WP-Admin settings page.
+ */
+function gutenbergtheme_options_page() { ?>
+	<div class="wrap">
+	<h1><?php _e('Gutenberg Starter Theme Options', 'gutenbergtheme'); ?></h1>
+
+	<form method="post" action="options.php">
+		<?php settings_fields( 'gutenbergtheme-options' ); ?>
+		<?php do_settings_sections( 'gutenbergtheme-options' ); ?>
+
+			<table class="form-table">
+				<tr valign="top">
+					<td>
+						<label for="gutenbergtheme-dark-mode">
+							<input name="gutenbergtheme-dark-mode" type="checkbox" value="1" <?php checked( '1', get_option( 'gutenbergtheme-dark-mode' ) ); ?> />
+							<?php _e( 'Enable a dark theme style for the editor.', 'gutenbergtheme' ); ?>
+							(<a href="https://developer.wordpress.org/block-editor/developers/themes/theme-support/#dark-backgrounds"><code>dark-editor-style</code></a>)
+						</label>
+					</td>
+				</tr>
+			</table>
+
+		<?php submit_button(); ?>
+	</form>
+	</div>
+<?php }
+
+
+/**
+ * Enable dark mode if gutenbergtheme-dark-mode setting is active.
+ */
+function gutenbergtheme_enable_dark_mode() {
+	if ( get_option( 'gutenbergtheme-dark-mode' ) == 1 ) {
+		
+		// Add support for editor styles.
+		add_theme_support( 'editor-styles' );
+		add_editor_style( 'style-editor-dark.css' );
+		
+		// Add support for dark styles.
+		add_theme_support( 'dark-editor-style' );
+	}
+}
+add_action( 'after_setup_theme', 'gutenbergtheme_enable_dark_mode' );

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -40,7 +40,7 @@ function gutenbergtheme_options_page() { ?>
 			<table class="form-table">
 				<tr valign="top">
 					<td>
-						<label for="gutenbergtheme-dark-mode">
+						<label>
 							<input name="gutenbergtheme-dark-mode" type="checkbox" value="1" <?php checked( '1', get_option( 'gutenbergtheme-dark-mode' ) ); ?> />
 							<?php _e( 'Enable a dark theme style for the editor.', 'gutenbergtheme' ); ?>
 							(<a href="https://developer.wordpress.org/block-editor/developers/themes/theme-support/#dark-backgrounds"><code>dark-editor-style</code></a>)

--- a/style-editor-dark.css
+++ b/style-editor-dark.css
@@ -1,0 +1,9 @@
+body {
+	background: #000;
+	color: #FFF;
+}
+
+.wp-block,
+.editor-post-title__block .editor-post-title__input {
+	color: #FFF;
+}


### PR DESCRIPTION
This PR adds a settings panel that lets users toggle a quick "Dark Mode" theme for the editor. It adds theme support for [`dark-editor-style`](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#dark-backgrounds), and enqueues a tiny editor stylesheet to make that visible. 

![theme-options](https://user-images.githubusercontent.com/1202812/58177704-dc8f3700-7c72-11e9-9bd5-300959296e9f.gif)

It's essentially a built-in way of enabling a fork I created a while back:
https://github.com/kjellr/gutenberg-starter-theme-dark/

In the future, this settings panel could be used for additional theme options (turning on and off custom colors, responsive embeds, etc.) in an effort to make testing easier.  