### PR TITLE
Add a simple widget area in footer.

### DIFF
--- a/404.php
+++ b/404.php
@@ -55,4 +55,5 @@ get_header(); ?>
 	</main><!-- #primary -->
 
 <?php
+get_sidebar();
 get_footer();

--- a/archive.php
+++ b/archive.php
@@ -45,4 +45,5 @@ get_header(); ?>
 	</main>><!-- #primary -->
 
 <?php
+get_sidebar();
 get_footer();

--- a/functions.php
+++ b/functions.php
@@ -178,6 +178,23 @@ function gutenbergtheme_scripts() {
 add_action( 'wp_enqueue_scripts', 'gutenbergtheme_scripts' );
 
 /**
+ * Register widget area.
+ */
+function gutenbergtheme_widgets_init() {
+	register_sidebar( array(
+		'name'          => esc_html__( 'Footer', 'gutenbergtheme' ),
+		'id'            => 'sidebar-1',
+		'description'   => esc_html__( 'Add widgets here.', 'gutenbergtheme' ),
+		'before_widget' => '<section id="%1$s" class="widget %2$s">',
+		'after_widget'  => '</section>',
+		'before_title'  => '<h2 class="widget-title">',
+		'after_title'   => '</h2>',
+	) );
+}
+add_action( 'widgets_init', 'gutenbergtheme_widgets_init' );
+
+
+/**
  * Implement the Custom Header feature.
  */
 require get_template_directory() . '/inc/custom-header.php';

--- a/index.php
+++ b/index.php
@@ -50,4 +50,5 @@ get_header(); ?>
 	</main><!-- #primary -->
 
 <?php
+get_sidebar();
 get_footer();

--- a/page.php
+++ b/page.php
@@ -32,4 +32,5 @@ get_header(); ?>
 	</main><!-- #primary -->
 
 <?php
+get_sidebar();
 get_footer();

--- a/search.php
+++ b/search.php
@@ -45,4 +45,5 @@ get_header(); ?>
 	</main><!-- #primary -->
 
 <?php
+get_sidebar();
 get_footer();

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * The main widget area
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ *
+ * @package Gutenbergtheme
+ */
+
+if ( ! is_active_sidebar( 'sidebar-1' ) ) {
+	return;
+}
+?>
+
+<aside id="secondary" class="widget-area">
+	<?php dynamic_sidebar( 'sidebar-1' ); ?>
+</aside><!-- #secondary -->

--- a/single.php
+++ b/single.php
@@ -32,4 +32,5 @@ get_header(); ?>
 	</main><!-- #primary -->
 
 <?php
+get_sidebar();
 get_footer();

--- a/style.css
+++ b/style.css
@@ -761,9 +761,6 @@ a:hover, a:active {
 /*--------------------------------------------------------------
 # Widgets
 --------------------------------------------------------------*/
-.widget-area {
-	width: 25%;
-}
 
 .widget {
   margin: 0 0 1.5em;
@@ -826,7 +823,8 @@ a:hover, a:active {
 .page-navigation,
 .comments-area,
 .not-found .page-content,
-.search .entry-summary {
+.search .entry-summary,
+.widget-area {
   margin: 1.5em auto;
   padding-left: 14px;
   padding-right: 14px;
@@ -857,7 +855,8 @@ a:hover, a:active {
   .page-navigation,
   .comments-area,
   .not-found .page-content,
-  .search .entry-summary {
+  .search .entry-summary,
+  .widget-area {
     padding-left: 0;
     padding-right: 0;
   }


### PR DESCRIPTION
... to make use of [Gutenberg 5.8's experimental widget feature](https://make.wordpress.org/core/2019/05/29/whats-new-in-gutenberg-29th-may/). 

Currently, if you load the widget screen while this theme is active, you can't test it out: 

![Screen Shot 2019-05-29 at 3 40 21 PM](https://user-images.githubusercontent.com/1202812/58586066-40dc6880-8228-11e9-928a-8e5b766c05f9.png)

This PR creates a barebones widget area on the bottom of the page, so that this feature can be tested without switching themes: 

![Screen Shot 2019-05-29 at 3 40 04 PM](https://user-images.githubusercontent.com/1202812/58586110-58b3ec80-8228-11e9-909e-74f5bbc39104.png)

![Screen Shot 2019-05-29 at 3 39 49 PM](https://user-images.githubusercontent.com/1202812/58586148-6c5f5300-8228-11e9-9909-4faf39352270.png)
