### PR TITLE
Clean up and evolve the included dark mode. 

### DIFF
--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -12,11 +12,11 @@ input,
 select,
 optgroup,
 textarea {
-  color: #BBB;
+  color: #E6E1DC;
 }
 
 h1, h2, h3, h4, h5, h6 {
-  color: #CDC8C3;
+  color: #E6E1DC;
 }
 
 abbr, acronym {

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -1,0 +1,160 @@
+/*--------------------------------------------------------------
+# Dark Mode
+--------------------------------------------------------------*/
+
+/*--------------------------------------------------------------
+## Typography
+--------------------------------------------------------------*/
+
+body,
+button,
+input,
+select,
+optgroup,
+textarea {
+  color: #BBB;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #CDC8C3;
+}
+
+abbr, acronym {
+  border-color: #999;
+}
+
+.site-title {
+  color: #CCCCCD;
+}
+
+body {
+  background: #000;
+}
+
+/*--------------------------------------------------------------
+## Forms
+--------------------------------------------------------------*/
+
+button,
+input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  border-color: #333 #333 #444;
+  background: #191919;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+button:hover,
+input[type="button"]:hover,
+input[type="reset"]:hover,
+input[type="submit"]:hover {
+  border-color: #333 #444 #555;
+}
+
+button:active, button:focus,
+input[type="button"]:active,
+input[type="button"]:focus,
+input[type="reset"]:active,
+input[type="reset"]:focus,
+input[type="submit"]:active,
+input[type="submit"]:focus {
+  border-color: #555 #444 #444;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="url"],
+input[type="password"],
+input[type="search"],
+input[type="number"],
+input[type="tel"],
+input[type="range"],
+input[type="date"],
+input[type="month"],
+input[type="week"],
+input[type="time"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="color"],
+textarea {
+  color: #999;
+  border-color: #333;
+}
+
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="url"]:focus,
+input[type="password"]:focus,
+input[type="search"]:focus,
+input[type="number"]:focus,
+input[type="tel"]:focus,
+input[type="range"]:focus,
+input[type="date"]:focus,
+input[type="month"]:focus,
+input[type="week"]:focus,
+input[type="time"]:focus,
+input[type="datetime"]:focus,
+input[type="datetime-local"]:focus,
+input[type="color"]:focus,
+textarea:focus {
+  color: #EEE;
+}
+
+select {
+  border-color: #333;
+}
+
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="url"]:focus,
+input[type="password"]:focus,
+input[type="search"]:focus,
+input[type="number"]:focus,
+input[type="tel"]:focus,
+input[type="range"]:focus,
+input[type="date"]:focus,
+input[type="month"]:focus,
+input[type="week"]:focus,
+input[type="time"]:focus,
+input[type="datetime"]:focus,
+input[type="datetime-local"]:focus,
+input[type="color"]:focus,
+textarea:focus {
+  color: #EEE;
+}
+
+fieldset {
+  border-color: #3F3F3F;
+}
+
+/*--------------------------------------------------------------
+## Links
+--------------------------------------------------------------*/
+
+a {
+  color: #00a0d2;
+}
+
+a:visited {
+  color: #CCC;
+}
+
+a:hover, a:focus, a:active {
+  color: #66c6e4;
+}
+
+/*--------------------------------------------------------------
+## Accessibility
+--------------------------------------------------------------*/
+
+.screen-reader-text:focus {
+  color: #66c6e4;
+}
+
+/*--------------------------------------------------------------
+## Posts and pages
+--------------------------------------------------------------*/
+
+.entry-footer {
+  border-color: #EEE;
+}

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -42,7 +42,7 @@ function gutenbergtheme_options_page() { ?>
 					<td>
 						<label>
 							<input name="gutenbergtheme-dark-mode" type="checkbox" value="1" <?php checked( '1', get_option( 'gutenbergtheme-dark-mode' ) ); ?> />
-							<?php _e( 'Enable a dark theme style for the editor.', 'gutenbergtheme' ); ?>
+							<?php _e( 'Enable a dark theme style.', 'gutenbergtheme' ); ?>
 							(<a href="https://developer.wordpress.org/block-editor/developers/themes/theme-support/#dark-backgrounds"><code>dark-editor-style</code></a>)
 						</label>
 					</td>
@@ -70,3 +70,13 @@ function gutenbergtheme_enable_dark_mode() {
 	}
 }
 add_action( 'after_setup_theme', 'gutenbergtheme_enable_dark_mode' );
+
+/**
+ * Enable dark mode on the front end if gutenbergtheme-dark-mode setting is active.
+ */
+function gutenbergtheme_enable_dark_mode_frontend_styles() {
+	if ( get_option( 'gutenbergtheme-dark-mode' ) == 1 ) {
+		wp_enqueue_style( 'gutenbergthemedark-style', get_template_directory_uri() . '/css/dark-mode.css' );
+	}
+}
+add_action( 'wp_enqueue_scripts', 'gutenbergtheme_enable_dark_mode_frontend_styles' );

--- a/style-editor-dark.css
+++ b/style-editor-dark.css
@@ -12,12 +12,9 @@ body {
 
 body,
 .wp-block,
-.editor-post-title__block .editor-post-title__input  {
-  color: #BBB;
-}
-
+.editor-post-title__block .editor-post-title__input,
 h1, h2, h3, h4, h5, h6 {
-  color: #CDC8C3;
+  color: #E6E1DC;
 }
 
 abbr, acronym {

--- a/style-editor-dark.css
+++ b/style-editor-dark.css
@@ -1,9 +1,43 @@
+/*--------------------------------------------------------------
+# Dark Mode Editor Styles
+--------------------------------------------------------------*/
+
 body {
 	background: #000;
-	color: #FFF;
 }
 
+/*--------------------------------------------------------------
+## Typography
+--------------------------------------------------------------*/
+
+body,
 .wp-block,
-.editor-post-title__block .editor-post-title__input {
-	color: #FFF;
+.editor-post-title__block .editor-post-title__input  {
+  color: #BBB;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #CDC8C3;
+}
+
+abbr, acronym {
+  border-color: #999;
+}
+
+/*--------------------------------------------------------------
+## Links
+--------------------------------------------------------------*/
+
+.wp-block a {
+  color: #00a0d2;
+}
+
+.wp-block a:visited {
+  color: #CCC;
+}
+
+.wp-block a:hover, 
+.wp-block a:focus, 
+.wp-block a:active {
+  color: #66c6e4;
 }

--- a/style.css
+++ b/style.css
@@ -287,7 +287,7 @@ input,
 select,
 optgroup,
 textarea {
-  color: #444;
+  color: #191e23;
   font-family: "Noto Serif", serif;
   font-size: 16px;
   font-size: 1rem;
@@ -295,7 +295,7 @@ textarea {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  color: #32373c;
+  color: #191e23;
   clear: both;
 }
 


### PR DESCRIPTION
#85 added a new "Dark mode" option to the theme. When activated, this would add theme support for `dark-editor-style`, and enqueue a simple editor stylesheet that swapped the background to black, and the text to white. 

This was a good, simple approach, but it was relatively basic. This PR expands on the previous one to include a more accurate and complete dark mode: 

- This PR expands the existing `style-editor-dark.css` stylesheet to include proper dark mode colors for some missing elements: namely links and headings. 
- It also includes a front-end stylesheet so that these colors are applied to the front end as well. 
- In order to have this be a more accurate dark mode, these stylesheets now use the complimentary color hex values for the grays used in the original theme. For instance, default body text was `#191E23` in light mode, and is now shown as `#E6E1DC` in the dark mode. This is what you'd get if you inverted the color in Photoshop. 
- For links in dark mode, I've kept those blue, but chosen lighter blue colors from the WordPress palette to maintain AA contrast ratios. 

**Screenshots:** 

![gutenberg test_2019_07_03_welcome-to-the-gutenberg-editor_(iPad)](https://user-images.githubusercontent.com/1202812/61634390-3904d780-ac5f-11e9-8749-cd11c7cba5e4.png)
![gutenberg test_wp-admin_post php_post=1215 action=edit(iPad) (3)](https://user-images.githubusercontent.com/1202812/61634391-399d6e00-ac5f-11e9-906b-4eaa91c23e1c.png)
