### PR TITLE
Clean up and refresh block styles

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -6,7 +6,7 @@
 }
 
 .entry-content > .alignwide {
-  max-width: 1100px;
+  max-width: 1070px;
 }
 
 .entry-content > .alignfull {
@@ -36,6 +36,14 @@
 
 .wp-block-image.alignfull img {
   width: 100vw;
+}
+
+.wp-block-image .alignleft img,
+.wp-block-image .alignright img,
+.wp-block-image .alignleft figcaption,
+.wp-block-image .alignright figcaption {
+  max-width: 100%;
+  width: 100%;
 }
 
 .wp-block-gallery:not(.components-placeholder) {
@@ -157,13 +165,13 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 }
 
 .wp-block-group > * {
-  max-width: 610px;
+  max-width: 554px;
   margin-left: auto;
   margin-right: auto;
 }
 
 .wp-block-group > .alignwide {
-  max-width: 1100px;
+  max-width: 1070px;
 }
 
 .wp-block-group > .alignfull {

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -129,6 +129,10 @@
   max-width: 100%;
 }
 
+.wp-block-group.has-background > .wp-block-group__inner-container > :first-child {
+  margin-top: 0;
+}
+
 .wp-block-group.has-background > .wp-block-group__inner-container > .alignfull {
   width: calc( 100% + 60px );
   max-width: calc( 100% + 60px );

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -114,8 +114,34 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   right: 0;
 }
 
-.wp-block-quote.is-large {
-  margin: 0 auto 16px;
+.wp-block-quote {
+  margin-left: 14px;
+  margin-right: 14px;
+  padding: 0;
+}
+
+@media screen and (min-width: 644px) {
+  .wp-block-quote {
+    margin: 36px auto;
+  }
+}
+
+.wp-block-quote > * {
+  margin-left: 1rem;
+}
+
+.wp-block-quote.is-large, 
+.wp-block-quote.is-style-large {
+  margin: 36px auto;
+  padding: 0;
+}
+
+.wp-block-quote.is-large cite, 
+.wp-block-quote.is-large footer, 
+.wp-block-quote.is-style-large cite, 
+.wp-block-quote.is-style-large footer {
+  font-size: 13px;
+  font-size: 0.8125rem;
 }
 
 .wp-block-pullquote>p:first-child {

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -54,8 +54,18 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 }
 
 .wp-block-table {
-  display: block;
   overflow-x: auto;
+  margin-left: 14px;
+  margin-right: 14px;
+  width: calc( 100% - 28px );
+}
+
+@media screen and (min-width: 664px) {
+  .wp-block-table {
+    margin-left: auto;
+    margin-right: auto;
+    width: 100%;
+  }
 }
 
 .wp-block-table table {

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -142,7 +142,7 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   left: -30px;
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 664px) {
   .wp-block-cover-text p {
     padding: 1.5em 0;
   }
@@ -152,6 +152,19 @@ ul.wp-block-latest-posts.is-grid.alignwide {
     padding-right: 0px;
   }
 
+}
+
+.wp-block-code {
+  padding: 0.8em 1em;
+  margin-left: 14px;
+  margin-right: 14px;
+}
+
+@media screen and (min-width: 664px) {
+  .wp-block-code {
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 /*--------------------------------------------------------------

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -1,3 +1,33 @@
+/*--------------------------------------------------------------
+>>> TABLE OF CONTENTS:
+----------------------------------------------------------------
+# General Structure
+  ## Code
+  ## Cover
+  ## Embeds
+  ## Gallery
+  ## Group
+  ## Image
+  ## Latest Posts
+  ## List
+  ## More
+  ## Pullquote
+  ## Quote
+  ## Separator
+  ## Table
+  ## Video
+# Additional Theme Styles
+  ## Color Palette
+--------------------------------------------------------------*/
+
+/*--------------------------------------------------------------
+# Block Styles
+--------------------------------------------------------------*/
+
+/*--------------------------------------------------------------
+## General Structure
+--------------------------------------------------------------*/
+
 .entry-content > * {
   margin: 36px auto;
   max-width: 580px;
@@ -14,16 +44,101 @@
   max-width: 100%;
 }
 
-.entry-content ul,
-.entry-content ol {
-  margin: 1.5em auto;
-  max-width: 580px;
-  list-style-position: outside;
+@media screen and (min-width: 608px) {
+  .entry-content > * {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
 }
 
-.wp-block-video video {
-  max-width: 580px;
+/*--------------------------------------------------------------
+## Code
+--------------------------------------------------------------*/
+
+.wp-block-code {
+  padding: 0.8em 1em;
+  margin-left: 14px;
+  margin-right: 14px;
 }
+
+@media screen and (min-width: 608px) {
+  .wp-block-code {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+/*--------------------------------------------------------------
+## Cover
+--------------------------------------------------------------*/
+
+.wp-block-cover-text p {
+  padding: 1.5em 14px;
+}
+
+@media screen and (min-width: 608px) {
+  .wp-block-cover-text p {
+    padding: 1.5em 0;
+  }
+}
+
+/*--------------------------------------------------------------
+## Embeds
+--------------------------------------------------------------*/
+
+.wp-block-embed.type-video > .wp-block-embed__wrapper {
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-top: 56.25%;
+}
+
+.wp-block-embed.type-video > .wp-block-embed__wrapper > iframe {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+
+/*--------------------------------------------------------------
+# Gallery
+--------------------------------------------------------------*/
+
+.wp-block-gallery:not(.components-placeholder) {
+  margin: 1.5em auto;
+}
+
+/*--------------------------------------------------------------
+## Group
+--------------------------------------------------------------*/
+
+.wp-block-group > .wp-block-group__inner-container > * {
+  max-width: 580px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.wp-block-group > .wp-block-group__inner-container > .alignwide {
+  max-width: 1070px;
+}
+
+.wp-block-group > .wp-block-group__inner-container > .alignfull {
+  max-width: 100%;
+}
+
+.wp-block-group.has-background > .wp-block-group__inner-container > .alignfull {
+  width: calc( 100% + 60px );
+  max-width: calc( 100% + 60px );
+  position: relative;
+  left: -30px;
+}
+
+/*--------------------------------------------------------------
+# Image
+--------------------------------------------------------------*/
 
 .wp-block-image img {
   display: block;
@@ -46,13 +161,9 @@
   width: 100%;
 }
 
-.wp-block-gallery:not(.components-placeholder) {
-  margin: 1.5em auto;
-}
-
-.wp-block-cover-text p {
-  padding: 1.5em 14px;
-}
+/*--------------------------------------------------------------
+## Latest Posts
+--------------------------------------------------------------*/
 
 ul.wp-block-latest-posts.alignwide,
 ul.wp-block-latest-posts.alignfull,
@@ -61,28 +172,15 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   padding: 0 14px;
 }
 
-.wp-block-table {
-  overflow-x: auto;
-  margin-left: 14px;
-  margin-right: 14px;
-  width: calc( 100% - 28px );
-}
+/*--------------------------------------------------------------
+# List
+--------------------------------------------------------------*/
 
-@media screen and (min-width: 608px) {
-  .wp-block-table {
-    margin-left: auto;
-    margin-right: auto;
-    width: 100%;
-  }
-}
-
-.wp-block-table table {
-  border-collapse: collapse;
-  width: 100%
-}
-
-.wp-block-table td, .wp-block-table th {
-  padding: .5em;
+.entry-content ul,
+.entry-content ol {
+  margin: 1.5em auto;
+  max-width: 580px;
+  list-style-position: outside;
 }
 
 .entry-content li {
@@ -103,34 +201,30 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   margin-left: 0;
 }
 
+/*--------------------------------------------------------------
+## More
+--------------------------------------------------------------*/
 
-.wp-block-embed.type-video > .wp-block-embed__wrapper {
-  position: relative;
-  width: 100%;
-  height: 0;
-  padding-top: 56.25%;
+.more-link {
+  display: block;
 }
 
-.wp-block-embed.type-video > .wp-block-embed__wrapper > iframe {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
+/*--------------------------------------------------------------
+## Pullquote
+--------------------------------------------------------------*/
+
+.wp-block-pullquote>p:first-child {
+  margin-top: 0;
 }
+
+/*--------------------------------------------------------------
+## Quote
+--------------------------------------------------------------*/
 
 .wp-block-quote {
   margin-left: 14px;
   margin-right: 14px;
   padding: 0;
-}
-
-@media screen and (min-width: 644px) {
-  .wp-block-quote {
-    margin: 36px auto;
-  }
 }
 
 .wp-block-quote > * {
@@ -151,68 +245,65 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   font-size: 0.8125rem;
 }
 
-.wp-block-pullquote>p:first-child {
-  margin-top: 0;
+@media screen and (min-width: 644px) {
+  .wp-block-quote {
+    margin: 36px auto;
+  }
 }
+
+/*--------------------------------------------------------------
+## Separator
+--------------------------------------------------------------*/
 
 .wp-block-separator {
   margin: 3em auto;
   padding: 0;
 }
 
-.more-link {
-	display: block;
-}
+/*--------------------------------------------------------------
+## Table
+--------------------------------------------------------------*/
 
-.wp-block-group > * {
-  max-width: 554px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.wp-block-group > .alignwide {
-  max-width: 1070px;
-}
-
-.wp-block-group > .alignfull {
-  max-width: 100%;
-}
-
-.wp-block-group.has-background > .alignfull {
-  width: calc( 100% + 60px );
-  max-width: calc( 100% + 60px );
-  position: relative;
-  left: -30px;
-}
-
-@media screen and (min-width: 608px) {
-  .wp-block-cover-text p {
-    padding: 1.5em 0;
-  }
-
-  .entry-content > * {
-    padding-left: 0px;
-    padding-right: 0px;
-  }
-
-}
-
-.wp-block-code {
-  padding: 0.8em 1em;
+.wp-block-table {
+  overflow-x: auto;
   margin-left: 14px;
   margin-right: 14px;
+  width: calc( 100% - 28px );
+}
+
+.wp-block-table table {
+  border-collapse: collapse;
+  width: 100%
+}
+
+.wp-block-table td, .wp-block-table th {
+  padding: .5em;
 }
 
 @media screen and (min-width: 608px) {
-  .wp-block-code {
+  .wp-block-table {
     margin-left: auto;
     margin-right: auto;
+    width: 100%;
   }
 }
 
 /*--------------------------------------------------------------
-# Block Color Palette Colors
+## Video
 --------------------------------------------------------------*/
+
+.wp-block-video video {
+  max-width: 580px;
+}
+
+/*--------------------------------------------------------------
+# Additional Theme Styles
+--------------------------------------------------------------*/
+
+/*--------------------------------------------------------------
+## Color Palette
+--------------------------------------------------------------*/
+
 .has-strong-blue-color {
   color: #0073aa;
 }

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -79,7 +79,6 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 
 .entry-content li {
   margin-left: 2.5em;
-  margin-bottom: 6px;
 }
 
 .entry-content ul ul,

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -1,6 +1,6 @@
 .entry-content > * {
   margin: 36px auto;
-  max-width: 636px;
+  max-width: 580px;
   padding-left: 14px;
   padding-right: 14px;
 }
@@ -17,12 +17,12 @@
 .entry-content ul,
 .entry-content ol {
   margin: 1.5em auto;
-  max-width: 636px;
+  max-width: 580px;
   list-style-position: outside;
 }
 
 .wp-block-video video {
-  max-width: 636px;
+  max-width: 580px;
 }
 
 .wp-block-image img {
@@ -60,7 +60,7 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   width: calc( 100% - 28px );
 }
 
-@media screen and (min-width: 664px) {
+@media screen and (min-width: 608px) {
   .wp-block-table {
     margin-left: auto;
     margin-right: auto;
@@ -177,7 +177,7 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   left: -30px;
 }
 
-@media screen and (min-width: 664px) {
+@media screen and (min-width: 608px) {
   .wp-block-cover-text p {
     padding: 1.5em 0;
   }
@@ -195,7 +195,7 @@ ul.wp-block-latest-posts.is-grid.alignwide {
   margin-right: 14px;
 }
 
-@media screen and (min-width: 664px) {
+@media screen and (min-width: 608px) {
   .wp-block-code {
     margin-left: auto;
     margin-right: auto;

--- a/style.css
+++ b/style.css
@@ -544,10 +544,6 @@ a {
   color: #0073aa;
 }
 
-a:visited {
-  color: #333;
-}
-
 a:hover, a:focus, a:active {
   color: #00a0d2;
 }

--- a/style.css
+++ b/style.css
@@ -318,7 +318,6 @@ address {
 }
 
 pre {
-  background: transparent;
   font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
   line-height: 1.6;
   margin-bottom: 1.6em;
@@ -336,6 +335,13 @@ code, kbd, tt, var {
   code, kbd, tt, var {
     font-size: 0.8125rem;
   }
+}
+
+p > code {
+  padding: 2px;
+  border-radius: 2px;
+  background: #f3f4f5;
+  font-size: inherit;
 }
 
 abbr, acronym {

--- a/style.css
+++ b/style.css
@@ -187,8 +187,8 @@ code,
 kbd,
 pre,
 samp {
-  font-family: monospace, monospace;
-  font-size: 1em;
+  font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+  font-size: 0.875rem;
 }
 
 button,
@@ -318,21 +318,24 @@ address {
 }
 
 pre {
-  background: #eee;
-  font-family: "Courier 10 Pitch", Courier, monospace;
-  font-size: 15px;
-  font-size: 0.9375rem;
+  background: transparent;
+  font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
   line-height: 1.6;
   margin-bottom: 1.6em;
   max-width: 100%;
   overflow: auto;
-  padding: 1.6em;
+  padding: 0.8em 1em;
 }
 
 code, kbd, tt, var {
   font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
-  font-size: 15px;
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
+}
+
+@media screen and (min-width: 600px) {
+  code, kbd, tt, var {
+    font-size: 0.8125rem;
+  }
 }
 
 abbr, acronym {

--- a/style.css
+++ b/style.css
@@ -566,7 +566,7 @@ a:hover, a:active {
 	clear: both;
 	display: block;
   margin: 0 auto;
-	max-width: 636px;
+	max-width: 580px;
   text-align: center;
 }
 
@@ -649,7 +649,7 @@ a:hover, a:active {
 .site-main .post-navigation {
   border-bottom: 1px solid #111;
 	margin: 0 auto 60px;
-  max-width: 636px;
+  max-width: 580px;
 	overflow: hidden;
   padding-bottom: 60px;
 }
@@ -718,7 +718,7 @@ a:hover, a:active {
 
 .alignleft,
 .alignright {
-	max-width: 636px !important;	/* Let's work to make this !important unnecessary */
+	max-width: 580px !important;	/* Let's work to make this !important unnecessary */
 }
 
 .alignleft img,
@@ -829,7 +829,7 @@ a:hover, a:active {
   margin: 1.5em auto;
   padding-left: 14px;
   padding-right: 14px;
-  max-width: 636px;
+  max-width: 580px;
 }
 
 .entry-header .wp-post-image {
@@ -847,7 +847,7 @@ a:hover, a:active {
   border-bottom: 1px solid #111;
 }
 
-@media screen and (min-width: 664px) {
+@media screen and (min-width: 608px) {
   .entry-header,
   .page-header,
   .entry-footer,


### PR DESCRIPTION
This became an unintentionally large PR — apologies for that. The changes accomplish the following: 

- In general, `blocks.css` should be way easier to read now. I've re-arranged the stylesheet so it has new headings and a table of contents to help find specific blocks styles. 
- It fixes some out-of-date styles too, in an effort to get the front end more in sync with default Gutenberg styles: 
	- Removes `a:visited` styles from links, since those aren't used in Gutenberg.
	- Restyles the Code block to match the editor appearance. 
	- Fixes a problem where tables did not take up the correct amount of horizontal space on the front end. 
	- Revises the content width and the width of wide items to match the editor's default styles (they were both too wide before). 
	- Cleans up the appearance of inline `code`, so that it appears like it does in the editor. 
	- Fixes a problem where left and right-aligned images were showing up half as large as they were supposed to on the front end.
	- Corrects the front-end display of the standard and large quote blocks. 
**Screenshots**

**Before**

![Screen Shot 2019-07-22 at 2 09 29 PM](https://user-images.githubusercontent.com/1202812/61654817-3fa94400-ac8b-11e9-9d9d-c44a54882105.png)
![Screen Shot 2019-07-22 at 2 09 40 PM](https://user-images.githubusercontent.com/1202812/61654818-3fa94400-ac8b-11e9-8aa5-5635d2f4bd83.png)
![Screen Shot 2019-07-22 at 2 15 10 PM](https://user-images.githubusercontent.com/1202812/61654819-3fa94400-ac8b-11e9-89b5-f71823f78c67.png)
![Screen Shot 2019-07-22 at 2 15 31 PM](https://user-images.githubusercontent.com/1202812/61654821-3fa94400-ac8b-11e9-867b-6abde6203344.png)
![Screen Shot 2019-07-22 at 2 18 01 PM](https://user-images.githubusercontent.com/1202812/61654949-8a2ac080-ac8b-11e9-8517-3de8971de0cb.png)


---

**After**

![Screen Shot 2019-07-22 at 2 16 52 PM](https://user-images.githubusercontent.com/1202812/61654868-636c8a00-ac8b-11e9-9191-b880738e78d7.png)
![Screen Shot 2019-07-22 at 2 16 49 PM](https://user-images.githubusercontent.com/1202812/61654869-636c8a00-ac8b-11e9-972e-38077a8ef1fd.png)
![Screen Shot 2019-07-22 at 2 16 59 PM](https://user-images.githubusercontent.com/1202812/61654870-636c8a00-ac8b-11e9-8bc9-eb06c13409a4.png)
![Screen Shot 2019-07-22 at 2 16 30 PM](https://user-images.githubusercontent.com/1202812/61654851-53ed4100-ac8b-11e9-9ee3-d8a9f6319338.png)
![Screen Shot 2019-07-22 at 2 17 37 PM](https://user-images.githubusercontent.com/1202812/61654918-7d0dd180-ac8b-11e9-9fad-7c83eea9d230.png)
