### PR TITLE
Move theme options into the customizer

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -34,7 +34,6 @@ function gutenberg_starter_theme_customize_register( $wp_customize ) {
 	 * Create Theme Options panel
 	 */
 	$wp_customize->add_section( 'gutenberg_starter_theme_options', array(
-		'priority'   => 1,
 		'capability' => 'edit_theme_options',
 		'title'      => esc_html__( 'Theme Options', 'gutenberg-starter-theme' ),
 	) );

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -6,11 +6,15 @@
  */
 
 /**
- * Add postMessage support for site title and description for the Theme Customizer.
+ * Add Theme Options for the Customizer.
  *
  * @param WP_Customize_Manager $wp_customize Theme Customizer object.
  */
 function gutenberg_starter_theme_customize_register( $wp_customize ) {
+	
+	/**
+	 * Add postMessage support for site title and description for the Theme Customizer.
+	 */
 	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
 	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
@@ -25,6 +29,76 @@ function gutenberg_starter_theme_customize_register( $wp_customize ) {
 			'render_callback' => 'gutenberg_starter_theme_customize_partial_blogdescription',
 		) );
 	}
+
+	/**
+	 * Create Theme Options panel
+	 */
+	$wp_customize->add_section( 'gutenberg_starter_theme_options', array(
+		'priority'   => 1,
+		'capability' => 'edit_theme_options',
+		'title'      => esc_html__( 'Theme Options', 'gutenberg-starter-theme' ),
+	) );
+
+	/**
+	 * Add setting: Align Wide
+	 */
+	$wp_customize->add_setting( 'gutenberg_starter_theme_align_wide', array(
+		'default'        => true
+	 ) );
+	$wp_customize->add_control( 'gutenberg_starter_theme_align_wide', array(
+		'section'   => 'gutenberg_starter_theme_options',
+		'label'     => __( 'Enable wide and full alignments.', 'gutenberg-starter-theme' ),
+		'type'      => 'checkbox'
+	) );
+
+	/**
+	 * Add setting: Color Palette
+	 */
+	$wp_customize->add_setting( 'gutenberg_starter_theme_color_palette', array(
+		'default'        => true
+	 ) );
+	$wp_customize->add_control( 'gutenberg_starter_theme_color_palette', array(
+		'section'   => 'gutenberg_starter_theme_options',
+		'label'     => __( 'Enable custom color palette in Gutenberg.', 'gutenberg-starter-theme' ),
+		'type'      => 'checkbox'
+	) );
+
+	/**
+	 * Add setting: Dark Mode
+	 */
+	$wp_customize->add_setting( 'gutenberg_starter_theme_dark_mode', array (
+		'default'        => false
+	) );
+	$wp_customize->add_control( 'gutenberg_starter_theme_dark_mode', array(
+		'section'   => 'gutenberg_starter_theme_options',
+		'label'     => __( 'Enable a dark theme style.', 'gutenberg-starter-theme' ),
+		'type'      => 'checkbox'
+	) );
+
+	/**
+	 * Add setting: Default Block Styles
+	 */
+	$wp_customize->add_setting( 'gutenberg_starter_theme_wp_block_styles', array(
+		'default'        => true
+	 ) );
+	$wp_customize->add_control( 'gutenberg_starter_theme_wp_block_styles', array(
+		'section'   => 'gutenberg_starter_theme_options',
+		'label'     => __( 'Enable default core block styles on the front end.', 'gutenberg-starter-theme' ),
+		'type'      => 'checkbox'
+	) );
+
+	/**
+	 * Add setting: Responsive Embeds
+	 */
+	$wp_customize->add_setting( 'gutenberg_starter_theme_responsive_embeds', array(
+		'default'        => true
+	 ) );
+	$wp_customize->add_control( 'gutenberg_starter_theme_responsive_embeds', array(
+		'section'   => 'gutenberg_starter_theme_options',
+		'label'     => __( 'Enable Enable responsive embedded content.', 'gutenberg-starter-theme' ),
+		'type'      => 'checkbox'
+	) );
+
 }
 add_action( 'customize_register', 'gutenberg_starter_theme_customize_register' );
 

--- a/inc/theme-options.php
+++ b/inc/theme-options.php
@@ -1,105 +1,10 @@
 <?php 
 
 /**
- * Set up a WP-Admin page for managing turning on and off theme features.
- */
-function gutenberg_starter_theme_add_options_page() {
-	add_theme_page(
-		'Theme Options',
-		'Theme Options',
-		'manage_options',
-		'gutenberg-starter-theme-options',
-		'gutenberg_starter_theme_options_page'
-	);
-
-	// Call register settings function
-	add_action( 'admin_init', 'gutenberg_starter_theme_options' );
-}
-add_action( 'admin_menu', 'gutenberg_starter_theme_add_options_page' );
-
-
-/**
- * Register settings for the WP-Admin page.
- */
-function gutenberg_starter_theme_options() {
-	register_setting( 'gutenberg-starter-theme-options', 'gutenberg-starter-theme-align-wide', array( 'default' => 1 ) );
-	register_setting( 'gutenberg-starter-theme-options', 'gutenberg-starter-theme-wp-block-styles', array( 'default' => 1 ) );
-	register_setting( 'gutenberg-starter-theme-options', 'gutenberg-starter-theme-editor-color-palette', array( 'default' => 1 ) );
-	register_setting( 'gutenberg-starter-theme-options', 'gutenberg-starter-theme-dark-mode' );
-	register_setting( 'gutenberg-starter-theme-options', 'gutenberg-starter-theme-responsive-embeds', array( 'default' => 1 ) );
-}
-
-
-/**
- * Build the WP-Admin settings page.
- */
-function gutenberg_starter_theme_options_page() { ?>
-	<div class="wrap">
-	<h1><?php _e('Gutenberg Starter Theme Options', 'gutenberg-starter-theme'); ?></h1>
-	<form method="post" action="options.php">
-		<?php settings_fields( 'gutenberg-starter-theme-options' ); ?>
-		<?php do_settings_sections( 'gutenberg-starter-theme-options' ); ?>
-
-			<table class="form-table">
-				<tr valign="top">
-					<td>
-						<label>
-							<input name="gutenberg-starter-theme-align-wide" type="checkbox" value="1" <?php checked( '1', get_option( 'gutenberg-starter-theme-align-wide' ) ); ?> />
-							<?php _e( 'Enable wide and full alignments.', 'gutenberg-starter-theme' ); ?>
-							(<a href="https://developer.wordpress.org/block-editor/developers/themes/theme-support/#wide-alignment"><code>align-wide</code></a>)
-						</label>
-					</td>
-				</tr>
-				<tr valign="top">
-					<td>
-						<label>
-							<input name="gutenberg-starter-theme-editor-color-palette" type="checkbox" value="1" <?php checked( '1', get_option( 'gutenberg-starter-theme-editor-color-palette' ) ); ?> />
-							<?php _e( 'Enable a custom theme color palette.', 'gutenberg-starter-theme' ); ?>
-							(<a href="https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-color-palettes"><code>editor-color-palette</code></a>)
-						</label>
-					</td>
-				</tr>
-				<tr valign="top">
-					<td>
-						<label>
-							<input name="gutenberg-starter-theme-dark-mode" type="checkbox" value="1" <?php checked( '1', get_option( 'gutenberg-starter-theme-dark-mode' ) ); ?> />
-							<?php _e( 'Enable a dark theme style.', 'gutenberg-starter-theme' ); ?>
-							(<a href="https://developer.wordpress.org/block-editor/developers/themes/theme-support/#dark-backgrounds"><code>dark-editor-style</code></a>)
-						</label>
-					</td>
-				</tr>
-				<tr valign="top">
-					<td>
-						<label>
-							<input name="gutenberg-starter-theme-wp-block-styles" type="checkbox" value="1" <?php checked( '1', get_option( 'gutenberg-starter-theme-wp-block-styles' ) ); ?> />
-							<?php _e( 'Enable core block styles on the front end.', 'gutenberg-starter-theme' ); ?>
-							(<a href="https://developer.wordpress.org/block-editor/developers/themes/theme-support/#default-block-styles"><code>wp-block-styles</code></a>)
-						</label>
-					</td>
-				</tr>
-				<tr valign="top">
-					<td>
-						<label>
-							<input name="gutenberg-starter-theme-responsive-embeds" type="checkbox" value="1" <?php checked( '1', get_option( 'gutenberg-starter-theme-responsive-embeds' ) ); ?> />
-							<?php _e( 'Enable responsive embedded content.', 'gutenberg-starter-theme' ); ?>
-							(<a href="https://developer.wordpress.org/block-editor/developers/themes/theme-support/#responsive-embedded-content"><code>responsive-embeds</code></a>)
-						</label>
-					</td>
-				</tr>
-			</table>
-
-		<?php submit_button(); ?>
-	</form>
-	</div>
-<?php }
-
-
-/**
  * Enable alignwide and alignfull support if the gutenberg-starter-theme-align-wide setting is active.
  */
 function gutenberg_starter_theme_enable_align_wide() {
-
-	if ( get_option( 'gutenberg-starter-theme-align-wide', 1 ) == 1 ) {
+	if ( true === get_theme_mod( 'gutenberg_starter_theme_align_wide' ) ) {
 		
 		// Add support for full and wide align images.
 		add_theme_support( 'align-wide' );
@@ -107,12 +12,11 @@ function gutenberg_starter_theme_enable_align_wide() {
 }
 add_action( 'after_setup_theme', 'gutenberg_starter_theme_enable_align_wide' );
 
-
 /**
  * Enable custom theme colors if the gutenberg-starter-theme-editor-color-palette setting is active.
  */
 function gutenberg_starter_theme_enable_editor_color_palette() {
-	if ( get_option( 'gutenberg-starter-theme-editor-color-palette', 1 ) == 1 ) {
+	if ( true === get_theme_mod( 'gutenberg_starter_theme_color_palette' ) ) {
 		
 		// Add support for a custom color scheme.
 		add_theme_support( 'editor-color-palette', array(
@@ -141,12 +45,11 @@ function gutenberg_starter_theme_enable_editor_color_palette() {
 }
 add_action( 'after_setup_theme', 'gutenberg_starter_theme_enable_editor_color_palette' );
 
-
 /**
  * Enable dark mode if gutenberg-starter-theme-dark-mode setting is active.
  */
 function gutenberg_starter_theme_enable_dark_mode() {
-	if ( get_option( 'gutenberg-starter-theme-dark-mode' ) == 1 ) {
+	if ( true === get_theme_mod( 'gutenberg_starter_theme_dark_mode' ) ) {
 		
 		// Add support for editor styles.
 		add_theme_support( 'editor-styles' );
@@ -158,12 +61,11 @@ function gutenberg_starter_theme_enable_dark_mode() {
 }
 add_action( 'after_setup_theme', 'gutenberg_starter_theme_enable_dark_mode' );
 
-
 /**
  * Enable dark mode on the front end if gutenberg-starter-theme-dark-mode setting is active.
  */
 function gutenberg_starter_theme_enable_dark_mode_frontend_styles() {
-	if ( get_option( 'gutenberg-starter-theme-dark-mode' ) == 1 ) {
+	if ( true === get_theme_mod( 'gutenberg_starter_theme_dark_mode' ) ) {
 		wp_enqueue_style( 'gutenberg-starter-themedark-style', get_template_directory_uri() . '/css/dark-mode.css' );
 	}
 }
@@ -173,8 +75,7 @@ add_action( 'wp_enqueue_scripts', 'gutenberg_starter_theme_enable_dark_mode_fron
  * Enable core block styles support if the gutenberg-starter-theme-wp-block-styles setting is active.
  */
 function gutenberg_starter_theme_enable_wp_block_styles() {
-
-	if ( get_option( 'gutenberg-starter-theme-wp-block-styles', 1 ) == 1 ) {
+	if ( true === get_theme_mod( 'gutenberg_starter_theme_wp_block_styles' ) ) {
 		
 		// Adding support for core block visual styles.
 		add_theme_support( 'wp-block-styles' );
@@ -182,13 +83,11 @@ function gutenberg_starter_theme_enable_wp_block_styles() {
 }
 add_action( 'after_setup_theme', 'gutenberg_starter_theme_enable_wp_block_styles' );
 
-
 /**
  * Enable responsive embedded content if the gutenberg-starter-theme-responsive-embeds setting is active.
  */
 function gutenberg_starter_theme_enable_responsive_embeds() {
-
-	if ( get_option( 'gutenberg-starter-theme-responsive-embeds', 1 ) == 1 ) {
+	if ( true === get_theme_mod( 'gutenberg_starter_theme_responsive_embeds' ) ) {
 		
 		// Adding support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );


### PR DESCRIPTION
In order to [align to TRT guidelines](https://make.wordpress.org/themes/2015/04/22/details-on-the-new-theme-settings-customizer-guideline/), we should move the Gutenberg Starter theme options out of a custom admin page and into the Customizer. This PR migrates these settings over. 

## Testing Instructions

1. Install the PR version of this theme on a test site, do not change any settings yet.
2. Ensure that the options above are all active by default:
	- You should see wide and full alignment options available in the editor.
	- You should see the custom theme color palette available in the editor.
	- You should see light mode active, not dark mode.
	- You should see default block styles applied on the frontend. (A quick way to check is to verify that the quote block appears with a left border).
	- On the front end, the body should have a wp-embed-responsive class.
3. Check and uncheck the new and verify that they toggle the options as expected.

## Screenshots

**Before:**

<img width="1080" alt="Screen Shot 2019-07-26 at 12 03 08 PM" src="https://user-images.githubusercontent.com/1202812/61965056-5a3a3080-af9d-11e9-9f64-bf0d349d3c37.png">

**After:**

<img width="1080" alt="Screen Shot 2019-07-26 at 12 02 34 PM" src="https://user-images.githubusercontent.com/1202812/61965035-4a225100-af9d-11e9-9f59-171bd16e9b36.png">
