### PR TITLE
Update readme.txt

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,3 +31,4 @@ Please let us know and we'll add you.
 | @Artisan-Asad | @artisticasad |
 | @LittleBigThing | @littlebigthing |
 | @marekhrabe | @marekhrabe |
+| @joyously | @joyously |

--- a/readme.txt
+++ b/readme.txt
@@ -1,19 +1,21 @@
 === gutenberg-starter-theme ===
 
-Contributors: everyone welcome
+Contributors: wordpressdotorg, aduth, artisticasad, crunnells, joen, karmatosed, kjellr, littlebigthing, marekhrabe, melchoyce, milana_cap, mor10, netweb, noisysocks, obenland, paulstonier, pento, richtabor, sharaz, shinichin, soean, sumobi
 Tags: translation-ready
-
-Requires at least: 4.0
-Tested up to: 4.8
+Requires at least: 5.0
+Tested up to: 5.2.2
+Requires PHP: 5.2.4
 Stable tag: 1.0.0
 License: GNU General Public License v2 or later
-License URI: LICENSE
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-A theme to demonstrate the power of the Gutenberg editor.
+A simple theme for testing Gutenberg.
 
 == Description ==
 
-Description
+The Gutenberg Starter theme is designed to provide a simple, interference-free theme for testing Gutenberg. It uses no editor styles by default, and is built so that its front-end appearance is as close to the editor's default Gutenberg styles as possible. 
+
+The theme is primarily intended for use by those developing for and testing Gutenberg, but may also be helpful for those developing themes, or for folks who would like their site to look like Gutenberg in general. 
 
 == Installation ==
 
@@ -23,13 +25,19 @@ Description
 
 == Frequently Asked Questions ==
 
-= Does this theme support any plugins? =
+= How do I adjust theme settings? =
 
-gutenberg-starter-theme includes support for Infinite Scroll in Jetpack.
+There are a few optional settings available in the `Appearance > Theme Options` panel added to WP-Admin. Each setting maps to a [theme support](https://developer.wordpress.org/block-editor/developers/themes/theme-support/) option offered by Gutenberg: 
+
+- [**Wide alignment**](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#wide-alignment). By default, wide and full alignments are active in the theme. This setting provides you the option to turn them off. 
+- [**Color palette**](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#block-color-palettes). The theme provides a limited custom color palette by default. This can be toggled off if you'd like to test the default Gutenberg colors. 
+- [**Dark background**](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#dark-backgrounds). Gutenberg provides some alternate UI colors, optimized for themes that use a dark background color. Turning this on will allow you to test those by enabling a dark mode of the theme. 
+- [**Block Styles**](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#default-block-styles). This option allows you to opt-in or out of having Gutenberg provide some structural CSS for certain blocks on the front end.
+- [**Responsive embedded content**](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#responsive-embedded-content). When this is active, embed blocks will automatically reflect the aspect ratio of content that is embedded in an iFrame.
 
 == Changelog ==
 
-= 1.0 - May 12 2015 =
+= 1.0 - August 5 2019 =
 * Initial release
 
 == Credits ==

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === gutenberg-starter-theme ===
 
-Contributors: wordpressdotorg, aduth, artisticasad, crunnells, joen, karmatosed, kjellr, littlebigthing, marekhrabe, melchoyce, milana_cap, mor10, netweb, noisysocks, obenland, paulstonier, pento, richtabor, sharaz, shinichin, soean, sumobi
+Contributors: wordpressdotorg, aduth, artisticasad, crunnells, joen, joyously, karmatosed, kjellr, littlebigthing, marekhrabe, melchoyce, milana_cap, mor10, netweb, noisysocks, obenland, paulstonier, pento, richtabor, sharaz, shinichin, soean, sumobi
 Tags: translation-ready
 Requires at least: 5.0
 Tested up to: 5.2.2


### PR DESCRIPTION
Fixes #95. 

Updates `readme.txt` with the current theme info. Also adds a minimum WP version requirement of 5.0. It technically works with earlier versions, but this theme is really all about Gutenberg, so I think that's reasonable. 

Marks today's date down as 1.0 in the changelog, but we can update that when the theme is actually launched in the repo. 

Thanks, @joyously for the heads up. This PR also adds you to the contributors list. 👍 