### PR TITLE
Added line-height and widget block screen support to the theme.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -79,6 +79,12 @@ if ( ! function_exists( 'gutenberg_starter_theme_setup' ) ) :
 			'flex-width'  => true,
 			'flex-height' => true,
 		) );
+
+		// Add theme support for the new Widget-blocks screen in wp-admin.
+		add_theme_support( 'block-based-widgets' );
+		
+		// Add theme support for custom line-height adjustements.
+		add_theme_support( 'experimental-line-height' );
 	}
 endif;
 add_action( 'after_setup_theme', 'gutenberg_starter_theme_setup' );


### PR DESCRIPTION
Some recent theme support options have been included in Gutenberg. I wanted to make sure the starter theme supported these.

- line-height
- widget-blocks screen