### PR TITLE
Add block based templates for FSE

### DIFF
--- a/block-template-parts/footer.html
+++ b/block-template-parts/footer.html
@@ -1,0 +1,3 @@
+<!-- wp:paragraph {"align":"center","fontSize":"small","style":{"color":{"text":"#6c7781"}}} -->
+<p class="has-text-align-center has-small-font-size" style="color:#6c7781">Proudly powered by <a href="https://wordpress.org">WordPress</a> | <a href="https://www.github.com/WordPress/gutenberg-starter-theme">The Gutenberg Starter Theme</a></p>
+<!-- /wp:paragraph -->

--- a/block-template-parts/header.html
+++ b/block-template-parts/header.html
@@ -1,0 +1,17 @@
+<!-- wp:spacer {"height":34} -->
+<div style="height:34px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+<!-- wp:site-title {"textAlign":"center"} /-->
+<!-- wp:site-tagline {"textAlign":"center","style":{"color":{"text":"#6c7781"}}} /-->
+<!-- wp:spacer {"height":34} -->
+<div style="height:34px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:navigation {"itemsJustification":"center"} -->
+<!-- wp:navigation-link {"label":"Home","title":"Home","type":"page","url":"/"} /-->
+
+<!-- wp:navigation-link {"label":"Blog","title":"Blog","url":"/blog"} /-->
+<!-- /wp:navigation -->
+<!-- wp:spacer {"height":52} -->
+<div style="height:52px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->

--- a/block-templates/index.html
+++ b/block-templates/index.html
@@ -1,0 +1,17 @@
+<!-- wp:group {"align":"full","className":"site-header"} -->
+<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"gutenberg-starter-theme"} /--></div></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","className":"site-content"} -->
+<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container">
+<!-- wp:query-loop -->
+<!-- wp:post-title /-->
+
+<!-- wp:post-content /-->
+<!-- /wp:query-loop -->
+</div></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","className":"site-footer"} -->
+<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"gutenberg-starter-theme"} /--></div></div>
+<!-- /wp:group -->

--- a/block-templates/single.html
+++ b/block-templates/single.html
@@ -1,0 +1,15 @@
+<!-- wp:group {"align":"full","className":"site-header"} -->
+<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"gutenberg-starter-theme"} /--></div></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","className":"site-content"} -->
+<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container">
+<!-- wp:post-title /-->
+<!-- wp:post-content /-->
+<!-- wp:post-comments /-->
+</div></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","className":"site-footer"} -->
+<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"gutenberg-starter-theme"} /--></div></div>
+<!-- /wp:group -->

--- a/css/blocks.css
+++ b/css/blocks.css
@@ -11,9 +11,11 @@
   ## Latest Posts
   ## List
   ## More
+  ## Navigation
   ## Pullquote
   ## Quote
   ## Separator
+  ## Site Tagline
   ## Table
   ## Video
 # Additional Theme Styles
@@ -115,7 +117,7 @@
 ## Group
 --------------------------------------------------------------*/
 
-.wp-block-group > .wp-block-group__inner-container > * {
+.wp-block-group > .wp-block-group__inner-container > *:not(.entry-content) {
   max-width: 580px;
   margin-left: auto;
   margin-right: auto;
@@ -214,6 +216,15 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 }
 
 /*--------------------------------------------------------------
+## Navigation
+--------------------------------------------------------------*/
+
+.wp-block-navigation-link__label {
+  font-family: inherit;
+  color: #0073aa;
+}
+
+/*--------------------------------------------------------------
 ## Pullquote
 --------------------------------------------------------------*/
 
@@ -262,6 +273,22 @@ ul.wp-block-latest-posts.is-grid.alignwide {
 .wp-block-separator {
   margin: 3em auto;
   padding: 0;
+}
+
+/*--------------------------------------------------------------
+## Site Tagline
+--------------------------------------------------------------*/
+
+.wp-block-site-tagline {
+  margin-top: 0;
+}
+
+/*--------------------------------------------------------------
+## Site Title
+--------------------------------------------------------------*/
+
+.wp-block-site-title {
+  margin-bottom: 0;
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
This PR adds some very basic block templates and template parts, along with a couple temporary styles to get them looking similar to the front end today. This lets folks start using the Full site editor with this theme today, but leaves things unchanged when the FSE experiment is turned off. 

This is just a starting point. The next step would be to add an `experimental-theme.json` file. 

## Testing

1. Activate this branch as your theme
2. Install the latest Gutenberg Plugin
3. Activate the Full Site Editing experiment from `Gutenberg > Experiments`. 
4. See that the front end of the site is close to its usual appearance, but is now editable via the beta full site editor. 

## Screenshots

Front end with FSE On (Before)|Front end with FSE On (After)
---|---
<img width="1080" alt="Screen Shot 2020-07-29 at 2 35 42 PM" src="https://user-images.githubusercontent.com/1202812/88839260-d1099b00-d1a8-11ea-8e90-fe82e5cf5124.png">|<img width="1252" alt="Screen Shot 2020-07-29 at 2 22 39 PM" src="https://user-images.githubusercontent.com/1202812/88839273-d535b880-d1a8-11ea-98a4-0fafb08955ce.png">

Full-site editor: 

<img width="1080" alt="Screen Shot 2020-07-29 at 2 38 43 PM" src="https://user-images.githubusercontent.com/1202812/88839546-39f11300-d1a9-11ea-96ae-a4a1f394976a.png">
